### PR TITLE
feat: item lookup endpoints — barcode and fuzzy search (#59)

### DIFF
--- a/client/src/api/schema.ts
+++ b/client/src/api/schema.ts
@@ -470,16 +470,9 @@ export interface components {
       types: components["schemas"]["ClothingTypeSummary"][]
     }
     ResolvedClothingItem: {
-      /** Format: int64 */
-      id: number
-      barcode?: string
-      typeName: string
-      size: string
-      /** Format: int64 */
-      currentLocationId?: number
-      currentLocationName?: string
-      /** @enum {string} */
-      currentLocationType?: "POOL" | "WAESCHE" | "PERSONAL" | "OTHER"
+      clothingItem: components["schemas"]["ClothingItem"]
+      location?: components["schemas"]["ClothingLocation"]
+      clothingType: components["schemas"]["ClothingType"]
     }
   }
   responses: never

--- a/client/src/api/schema.ts
+++ b/client/src/api/schema.ts
@@ -295,6 +295,40 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  "/api/clothing/items/search": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Search clothing items by type name, size, or barcode */
+    get: operations["searchItems"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/clothing/items/by-barcode/{barcode}": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Look up a clothing item by barcode */
+    get: operations["getItemByBarcode"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
 }
 export type webhooks = Record<string, never>
 export interface components {
@@ -434,6 +468,18 @@ export interface components {
       locationId: number
       locationName: string
       types: components["schemas"]["ClothingTypeSummary"][]
+    }
+    ResolvedClothingItem: {
+      /** Format: int64 */
+      id: number
+      barcode?: string
+      typeName: string
+      size: string
+      /** Format: int64 */
+      currentLocationId?: number
+      currentLocationName?: string
+      /** @enum {string} */
+      currentLocationType?: "POOL" | "WAESCHE" | "PERSONAL" | "OTHER"
     }
   }
   responses: never
@@ -1075,6 +1121,51 @@ export interface operations {
         }
         content: {
           "*/*": components["schemas"]["ClothingLocationSummary"][]
+        }
+      }
+    }
+  }
+  searchItems: {
+    parameters: {
+      query: {
+        q: string
+        limit?: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["ResolvedClothingItem"][]
+        }
+      }
+    }
+  }
+  getItemByBarcode: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        barcode: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["ResolvedClothingItem"]
         }
       }
     }

--- a/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ClothingItemController.kt
+++ b/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ClothingItemController.kt
@@ -6,6 +6,7 @@ import jakarta.validation.Valid
 import jakarta.validation.constraints.Positive
 import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.Authentication
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -14,13 +15,17 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/clothing/items")
 @Validated
-class ClothingItemController(private val service: ClothingItemService) {
+class ClothingItemController(
+    private val service: ClothingItemService,
+    private val lookupService: ClothingItemLookupService,
+) {
 
     @GetMapping
     @Operation(summary = "List all clothing items")
@@ -31,6 +36,23 @@ class ClothingItemController(private val service: ClothingItemService) {
     fun getItemById(
         @Parameter(description = "ID of the clothing item") @PathVariable @Positive id: Long
     ): ClothingItem = service.getItemById(id)
+
+    @GetMapping("/by-barcode/{barcode}")
+    @Operation(summary = "Look up a clothing item by barcode")
+    fun getItemByBarcode(
+        @PathVariable barcode: String,
+        authentication: Authentication,
+    ): ResolvedClothingItem =
+        lookupService.findByBarcode(barcode, isKleiderwart = authentication.isKleiderwart())
+
+    @GetMapping("/search")
+    @Operation(summary = "Search clothing items by type name, size, or barcode")
+    fun searchItems(
+        @RequestParam q: String,
+        @RequestParam(defaultValue = "50") limit: Int,
+        authentication: Authentication,
+    ): List<ResolvedClothingItem> =
+        lookupService.search(q, limit, isKleiderwart = authentication.isKleiderwart())
 
     @PostMapping
     @Operation(summary = "Create a new clothing item")
@@ -63,3 +85,6 @@ class ClothingItemController(private val service: ClothingItemService) {
         service.deleteItem(id)
     }
 }
+
+private fun Authentication.isKleiderwart(): Boolean =
+    authorities.any { it.authority == "ROLE_KLEIDERWART" }

--- a/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ClothingItemLookupService.kt
+++ b/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ClothingItemLookupService.kt
@@ -29,11 +29,7 @@ class ClothingItemLookupService(
             typeRepository.findById(item.typeId.id)
                 ?: throw NotFoundException("Type not found for item ${item.id}")
 
-        return ResolvedClothingItem(
-            clothingItem = item,
-            location = location,
-            clothingType = type,
-        )
+        return ResolvedClothingItem(clothingItem = item, location = location, clothingType = type)
     }
 
     fun search(q: String, limit: Int, isKleiderwart: Boolean): List<ResolvedClothingItem> {
@@ -61,7 +57,8 @@ class ClothingItemLookupService(
                 ResolvedClothingItem(
                     clothingItem = item,
                     location = location,
-                    clothingType = types[item.typeId.id] ?: error("Type not found for item ${item.id}"),
+                    clothingType =
+                        types[item.typeId.id] ?: error("Type not found for item ${item.id}"),
                 )
             }
             .toList()

--- a/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ClothingItemLookupService.kt
+++ b/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ClothingItemLookupService.kt
@@ -1,0 +1,78 @@
+package io.github.simonhauck.openfirestationmanager.clothing.item
+
+import io.github.simonhauck.openfirestationmanager.clothing.location.ClothingLocationRepository
+import io.github.simonhauck.openfirestationmanager.clothing.type.ClothingTypeRepository
+import io.github.simonhauck.openfirestationmanager.common.NotFoundException
+import org.springframework.stereotype.Service
+
+private const val SEARCH_RESULT_CAP = 50
+
+@Service
+class ClothingItemLookupService(
+    private val itemRepository: ClothingItemRepository,
+    private val typeRepository: ClothingTypeRepository,
+    private val locationRepository: ClothingLocationRepository,
+) {
+
+    fun findByBarcode(barcode: String, isKleiderwart: Boolean): ResolvedClothingItem {
+        val item =
+            itemRepository.findByBarcode(barcode)
+                ?: throw NotFoundException("Item not found for barcode: $barcode")
+
+        val location = item.locationId?.id?.let { locationRepository.findById(it) }
+
+        if (location != null && location.onlyVisibleForKleiderwart && !isKleiderwart) {
+            throw NotFoundException("Item not found for barcode: $barcode")
+        }
+
+        val type =
+            typeRepository.findById(item.typeId.id!!)
+                ?: throw NotFoundException("Type not found for item ${item.id}")
+
+        return ResolvedClothingItem(
+            id = item.id,
+            barcode = item.barcode,
+            typeName = type.name,
+            size = item.size,
+            currentLocationId = location?.id,
+            currentLocationName = location?.name,
+            currentLocationType = location?.type,
+        )
+    }
+
+    fun search(q: String, limit: Int, isKleiderwart: Boolean): List<ResolvedClothingItem> {
+        val effectiveLimit = minOf(limit, SEARCH_RESULT_CAP)
+        val query = q.lowercase()
+
+        val types = typeRepository.findAll().associateBy { it.id }
+        val locations = locationRepository.findAll().associateBy { it.id }
+
+        return itemRepository
+            .findAll()
+            .asSequence()
+            .filter { item ->
+                val location = item.locationId?.id?.let { locations[it] }
+                if (location != null && location.onlyVisibleForKleiderwart && !isKleiderwart)
+                    return@filter false
+                val typeName = types[item.typeId.id]?.name ?: ""
+                typeName.lowercase().contains(query) ||
+                    item.size.lowercase().contains(query) ||
+                    (item.barcode?.lowercase()?.contains(query) == true)
+            }
+            .take(effectiveLimit)
+            .map { item ->
+                val location = item.locationId?.id?.let { locations[it] }
+                val typeName = types[item.typeId.id]?.name ?: ""
+                ResolvedClothingItem(
+                    id = item.id,
+                    barcode = item.barcode,
+                    typeName = typeName,
+                    size = item.size,
+                    currentLocationId = location?.id,
+                    currentLocationName = location?.name,
+                    currentLocationType = location?.type,
+                )
+            }
+            .toList()
+    }
+}

--- a/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ClothingItemLookupService.kt
+++ b/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ClothingItemLookupService.kt
@@ -26,17 +26,13 @@ class ClothingItemLookupService(
         }
 
         val type =
-            typeRepository.findById(item.typeId.id!!)
+            typeRepository.findById(item.typeId.id)
                 ?: throw NotFoundException("Type not found for item ${item.id}")
 
         return ResolvedClothingItem(
-            id = item.id,
-            barcode = item.barcode,
-            typeName = type.name,
-            size = item.size,
-            currentLocationId = location?.id,
-            currentLocationName = location?.name,
-            currentLocationType = location?.type,
+            clothingItem = item,
+            location = location,
+            clothingType = type,
         )
     }
 
@@ -62,15 +58,10 @@ class ClothingItemLookupService(
             .take(effectiveLimit)
             .map { item ->
                 val location = item.locationId?.id?.let { locations[it] }
-                val typeName = types[item.typeId.id]?.name ?: ""
                 ResolvedClothingItem(
-                    id = item.id,
-                    barcode = item.barcode,
-                    typeName = typeName,
-                    size = item.size,
-                    currentLocationId = location?.id,
-                    currentLocationName = location?.name,
-                    currentLocationType = location?.type,
+                    clothingItem = item,
+                    location = location,
+                    clothingType = types[item.typeId.id] ?: error("Type not found for item ${item.id}"),
                 )
             }
             .toList()

--- a/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ResolvedClothingItem.kt
+++ b/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ResolvedClothingItem.kt
@@ -1,0 +1,13 @@
+package io.github.simonhauck.openfirestationmanager.clothing.item
+
+import io.github.simonhauck.openfirestationmanager.clothing.location.LocationType
+
+data class ResolvedClothingItem(
+    val id: Long,
+    val barcode: String?,
+    val typeName: String,
+    val size: String,
+    val currentLocationId: Long?,
+    val currentLocationName: String?,
+    val currentLocationType: LocationType?,
+)

--- a/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ResolvedClothingItem.kt
+++ b/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ResolvedClothingItem.kt
@@ -1,13 +1,10 @@
 package io.github.simonhauck.openfirestationmanager.clothing.item
 
-import io.github.simonhauck.openfirestationmanager.clothing.location.LocationType
+import io.github.simonhauck.openfirestationmanager.clothing.location.ClothingLocation
+import io.github.simonhauck.openfirestationmanager.clothing.type.ClothingType
 
 data class ResolvedClothingItem(
-    val id: Long,
-    val barcode: String?,
-    val typeName: String,
-    val size: String,
-    val currentLocationId: Long?,
-    val currentLocationName: String?,
-    val currentLocationType: LocationType?,
+    val clothingItem: ClothingItem,
+    val location: ClothingLocation?,
+    val clothingType: ClothingType,
 )

--- a/server/src/main/resources/open-api-contract.json
+++ b/server/src/main/resources/open-api-contract.json
@@ -1,41 +1,43 @@
 {
-  "openapi" : "3.1.0",
-  "info" : {
-    "title" : "OpenAPI definition",
-    "version" : "v0"
+  "openapi": "3.1.0",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
   },
-  "paths" : {
-    "/api/admin/users/{id}/password" : {
-      "put" : {
-        "tags" : [ "admin-user-controller" ],
-        "operationId" : "changePassword",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int64",
-            "exclusiveMinimum" : 0
+  "paths": {
+    "/api/admin/users/{id}/password": {
+      "put": {
+        "tags": ["admin-user-controller"],
+        "operationId": "changePassword",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "exclusiveMinimum": 0
+            }
           }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/ChangePasswordRequest"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChangePasswordRequest"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/UserAccount"
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserAccount"
                 }
               }
             }
@@ -43,27 +45,27 @@
         }
       }
     },
-    "/api/public/setup/initial-admin" : {
-      "post" : {
-        "tags" : [ "initial-setup-controller" ],
-        "operationId" : "initializeAdmin",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/InitialAdminSetupRequest"
+    "/api/public/setup/initial-admin": {
+      "post": {
+        "tags": ["initial-setup-controller"],
+        "operationId": "initializeAdmin",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InitialAdminSetupRequest"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/UserAccount"
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserAccount"
                 }
               }
             }
@@ -71,54 +73,54 @@
         }
       }
     },
-    "/api/public/auth/logout" : {
-      "post" : {
-        "tags" : [ "auth-controller" ],
-        "operationId" : "logout",
-        "responses" : {
-          "204" : {
-            "description" : "No Content",
-            "content" : { }
+    "/api/public/auth/logout": {
+      "post": {
+        "tags": ["auth-controller"],
+        "operationId": "logout",
+        "responses": {
+          "204": {
+            "description": "No Content",
+            "content": {}
           }
         }
       }
     },
-    "/api/public/auth/login" : {
-      "post" : {
-        "tags" : [ "auth-controller" ],
-        "operationId" : "login",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/LoginRequest"
+    "/api/public/auth/login": {
+      "post": {
+        "tags": ["auth-controller"],
+        "operationId": "login",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginRequest"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : { }
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {}
           }
         }
       }
     },
-    "/api/clothing/types" : {
-      "get" : {
-        "tags" : [ "clothing-type-controller" ],
-        "summary" : "List all protective clothing types",
-        "operationId" : "getAllTypes",
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ClothingType"
+    "/api/clothing/types": {
+      "get": {
+        "tags": ["clothing-type-controller"],
+        "summary": "List all protective clothing types",
+        "operationId": "getAllTypes",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ClothingType"
                   }
                 }
               }
@@ -126,27 +128,27 @@
           }
         }
       },
-      "post" : {
-        "tags" : [ "clothing-type-controller" ],
-        "summary" : "Create a new protective clothing type",
-        "operationId" : "createType",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/CreateOrUpdateClothingTypeRequest"
+      "post": {
+        "tags": ["clothing-type-controller"],
+        "summary": "Create a new protective clothing type",
+        "operationId": "createType",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateOrUpdateClothingTypeRequest"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ClothingType"
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClothingType"
                 }
               }
             }
@@ -154,20 +156,20 @@
         }
       }
     },
-    "/api/clothing/locations" : {
-      "get" : {
-        "tags" : [ "clothing-location-controller" ],
-        "summary" : "List all clothing locations",
-        "operationId" : "getAllLocations",
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ClothingLocation"
+    "/api/clothing/locations": {
+      "get": {
+        "tags": ["clothing-location-controller"],
+        "summary": "List all clothing locations",
+        "operationId": "getAllLocations",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ClothingLocation"
                   }
                 }
               }
@@ -175,27 +177,27 @@
           }
         }
       },
-      "post" : {
-        "tags" : [ "clothing-location-controller" ],
-        "summary" : "Create a new clothing location",
-        "operationId" : "createLocation",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/CreateClothingLocationRequest"
+      "post": {
+        "tags": ["clothing-location-controller"],
+        "summary": "Create a new clothing location",
+        "operationId": "createLocation",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateClothingLocationRequest"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ClothingLocation"
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClothingLocation"
                 }
               }
             }
@@ -203,111 +205,30 @@
         }
       }
     },
-    "/api/clothing/locations/batch" : {
-      "post" : {
-        "tags" : [ "clothing-location-controller" ],
-        "summary" : "Create multiple clothing locations in a single request",
-        "operationId" : "createBatchLocations",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/BatchCreateClothingLocationsRequest"
+    "/api/clothing/locations/batch": {
+      "post": {
+        "tags": ["clothing-location-controller"],
+        "summary": "Create multiple clothing locations in a single request",
+        "operationId": "createBatchLocations",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchCreateClothingLocationsRequest"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ClothingLocation"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/clothing/items" : {
-      "get" : {
-        "tags" : [ "clothing-item-controller" ],
-        "summary" : "List all clothing items",
-        "operationId" : "getAllItems",
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ClothingItem"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "post" : {
-        "tags" : [ "clothing-item-controller" ],
-        "summary" : "Create a new clothing item",
-        "operationId" : "createItem",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/CreateOrUpdateClothingItemRequest"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ClothingItem"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/clothing/items/batch" : {
-      "post" : {
-        "tags" : [ "clothing-item-controller" ],
-        "summary" : "Create multiple clothing items in a single request",
-        "operationId" : "createBatchItems",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/BatchCreateClothingItemsRequest"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ClothingItem"
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ClothingLocation"
                   }
                 }
               }
@@ -316,19 +237,20 @@
         }
       }
     },
-    "/api/admin/users" : {
-      "get" : {
-        "tags" : [ "admin-user-controller" ],
-        "operationId" : "getAllUsers",
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/UserAccount"
+    "/api/clothing/items": {
+      "get": {
+        "tags": ["clothing-item-controller"],
+        "summary": "List all clothing items",
+        "operationId": "getAllItems",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ClothingItem"
                   }
                 }
               }
@@ -336,26 +258,27 @@
           }
         }
       },
-      "post" : {
-        "tags" : [ "admin-user-controller" ],
-        "operationId" : "createUser",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/CreateUserRequest"
+      "post": {
+        "tags": ["clothing-item-controller"],
+        "summary": "Create a new clothing item",
+        "operationId": "createItem",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateOrUpdateClothingItemRequest"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/UserAccount"
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClothingItem"
                 }
               }
             }
@@ -363,369 +286,30 @@
         }
       }
     },
-    "/api/clothing/types/{id}" : {
-      "get" : {
-        "tags" : [ "clothing-type-controller" ],
-        "summary" : "Get a protective clothing type by ID",
-        "operationId" : "getTypeById",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the protective clothing type",
-          "required" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int64",
-            "exclusiveMinimum" : 0
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ClothingType"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete" : {
-        "tags" : [ "clothing-type-controller" ],
-        "summary" : "Delete a protective clothing type",
-        "operationId" : "deleteType",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the protective clothing type",
-          "required" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int64",
-            "exclusiveMinimum" : 0
-          }
-        } ],
-        "responses" : {
-          "204" : {
-            "description" : "No Content"
-          }
-        }
-      },
-      "patch" : {
-        "tags" : [ "clothing-type-controller" ],
-        "summary" : "Update a protective clothing type",
-        "operationId" : "updateType",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the protective clothing type",
-          "required" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int64",
-            "exclusiveMinimum" : 0
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/CreateOrUpdateClothingTypeRequest"
+    "/api/clothing/items/batch": {
+      "post": {
+        "tags": ["clothing-item-controller"],
+        "summary": "Create multiple clothing items in a single request",
+        "operationId": "createBatchItems",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchCreateClothingItemsRequest"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ClothingType"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/clothing/locations/{id}" : {
-      "get" : {
-        "tags" : [ "clothing-location-controller" ],
-        "summary" : "Get a clothing location by ID",
-        "operationId" : "getLocationById",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the clothing location",
-          "required" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int64",
-            "exclusiveMinimum" : 0
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ClothingLocation"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete" : {
-        "tags" : [ "clothing-location-controller" ],
-        "summary" : "Delete a clothing location",
-        "operationId" : "deleteLocation",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the clothing location",
-          "required" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int64",
-            "exclusiveMinimum" : 0
-          }
-        } ],
-        "responses" : {
-          "204" : {
-            "description" : "No Content"
-          }
-        }
-      },
-      "patch" : {
-        "tags" : [ "clothing-location-controller" ],
-        "summary" : "Update a clothing location",
-        "operationId" : "updateLocation",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the clothing location",
-          "required" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int64",
-            "exclusiveMinimum" : 0
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/CreateClothingLocationRequest"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ClothingLocation"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/clothing/items/{id}" : {
-      "get" : {
-        "tags" : [ "clothing-item-controller" ],
-        "summary" : "Get a clothing item by ID",
-        "operationId" : "getItemById",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the clothing item",
-          "required" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int64",
-            "exclusiveMinimum" : 0
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ClothingItem"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete" : {
-        "tags" : [ "clothing-item-controller" ],
-        "summary" : "Delete a clothing item",
-        "operationId" : "deleteItem",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the clothing item",
-          "required" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int64",
-            "exclusiveMinimum" : 0
-          }
-        } ],
-        "responses" : {
-          "204" : {
-            "description" : "No Content"
-          }
-        }
-      },
-      "patch" : {
-        "tags" : [ "clothing-item-controller" ],
-        "summary" : "Update a clothing item",
-        "operationId" : "updateItem",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the clothing item",
-          "required" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int64",
-            "exclusiveMinimum" : 0
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/CreateOrUpdateClothingItemRequest"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ClothingItem"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/admin/users/{id}" : {
-      "get" : {
-        "tags" : [ "admin-user-controller" ],
-        "operationId" : "getUserById",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int64",
-            "exclusiveMinimum" : 0
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/UserAccount"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch" : {
-        "tags" : [ "admin-user-controller" ],
-        "operationId" : "updateUser",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int64",
-            "exclusiveMinimum" : 0
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/UpdateUserRequest"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/UserAccount"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/public/auth/me" : {
-      "get" : {
-        "tags" : [ "auth-controller" ],
-        "operationId" : "me",
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AuthStateResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/clothing/overview/summary/type" : {
-      "get" : {
-        "tags" : [ "clothing-overview-controller" ],
-        "summary" : "List clothing item counts by type and size",
-        "operationId" : "getSummariesByType",
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ClothingTypeSummary"
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ClothingItem"
                   }
                 }
               }
@@ -734,20 +318,438 @@
         }
       }
     },
-    "/api/clothing/overview/dashboard/location" : {
-      "get" : {
-        "tags" : [ "clothing-overview-controller" ],
-        "summary" : "Get clothing availability overview for dashboard locations",
-        "operationId" : "getDashboardLocationSummaries",
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ClothingLocationSummary"
+    "/api/admin/users": {
+      "get": {
+        "tags": ["admin-user-controller"],
+        "operationId": "getAllUsers",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UserAccount"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["admin-user-controller"],
+        "operationId": "createUser",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateUserRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserAccount"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/clothing/types/{id}": {
+      "get": {
+        "tags": ["clothing-type-controller"],
+        "summary": "Get a protective clothing type by ID",
+        "operationId": "getTypeById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the protective clothing type",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "exclusiveMinimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClothingType"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["clothing-type-controller"],
+        "summary": "Delete a protective clothing type",
+        "operationId": "deleteType",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the protective clothing type",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "exclusiveMinimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        }
+      },
+      "patch": {
+        "tags": ["clothing-type-controller"],
+        "summary": "Update a protective clothing type",
+        "operationId": "updateType",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the protective clothing type",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "exclusiveMinimum": 0
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateOrUpdateClothingTypeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClothingType"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/clothing/locations/{id}": {
+      "get": {
+        "tags": ["clothing-location-controller"],
+        "summary": "Get a clothing location by ID",
+        "operationId": "getLocationById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the clothing location",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "exclusiveMinimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClothingLocation"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["clothing-location-controller"],
+        "summary": "Delete a clothing location",
+        "operationId": "deleteLocation",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the clothing location",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "exclusiveMinimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        }
+      },
+      "patch": {
+        "tags": ["clothing-location-controller"],
+        "summary": "Update a clothing location",
+        "operationId": "updateLocation",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the clothing location",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "exclusiveMinimum": 0
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateClothingLocationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClothingLocation"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/clothing/items/{id}": {
+      "get": {
+        "tags": ["clothing-item-controller"],
+        "summary": "Get a clothing item by ID",
+        "operationId": "getItemById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the clothing item",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "exclusiveMinimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClothingItem"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["clothing-item-controller"],
+        "summary": "Delete a clothing item",
+        "operationId": "deleteItem",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the clothing item",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "exclusiveMinimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        }
+      },
+      "patch": {
+        "tags": ["clothing-item-controller"],
+        "summary": "Update a clothing item",
+        "operationId": "updateItem",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the clothing item",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "exclusiveMinimum": 0
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateOrUpdateClothingItemRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClothingItem"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/users/{id}": {
+      "get": {
+        "tags": ["admin-user-controller"],
+        "operationId": "getUserById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "exclusiveMinimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserAccount"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": ["admin-user-controller"],
+        "operationId": "updateUser",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "exclusiveMinimum": 0
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateUserRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserAccount"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/auth/me": {
+      "get": {
+        "tags": ["auth-controller"],
+        "operationId": "me",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthStateResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/clothing/overview/summary/type": {
+      "get": {
+        "tags": ["clothing-overview-controller"],
+        "summary": "List clothing item counts by type and size",
+        "operationId": "getSummariesByType",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ClothingTypeSummary"
                   }
                 }
               }
@@ -756,37 +758,20 @@
         }
       }
     },
-    "/api/clothing/items/search" : {
-      "get" : {
-        "tags" : [ "clothing-item-controller" ],
-        "summary" : "Search clothing items by type name, size, or barcode",
-        "operationId" : "searchItems",
-        "parameters" : [ {
-          "name" : "q",
-          "in" : "query",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "limit",
-          "in" : "query",
-          "required" : false,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int32",
-            "default" : 50
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ResolvedClothingItem"
+    "/api/clothing/overview/dashboard/location": {
+      "get": {
+        "tags": ["clothing-overview-controller"],
+        "summary": "Get clothing availability overview for dashboard locations",
+        "operationId": "getDashboardLocationSummaries",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ClothingLocationSummary"
                   }
                 }
               }
@@ -795,26 +780,70 @@
         }
       }
     },
-    "/api/clothing/items/by-barcode/{barcode}" : {
-      "get" : {
-        "tags" : [ "clothing-item-controller" ],
-        "summary" : "Look up a clothing item by barcode",
-        "operationId" : "getItemByBarcode",
-        "parameters" : [ {
-          "name" : "barcode",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/api/clothing/items/search": {
+      "get": {
+        "tags": ["clothing-item-controller"],
+        "summary": "Search clothing items by type name, size, or barcode",
+        "operationId": "searchItems",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 50
+            }
           }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ResolvedClothingItem"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ResolvedClothingItem"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/clothing/items/by-barcode/{barcode}": {
+      "get": {
+        "tags": ["clothing-item-controller"],
+        "summary": "Look up a clothing item by barcode",
+        "operationId": "getItemByBarcode",
+        "parameters": [
+          {
+            "name": "barcode",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResolvedClothingItem"
                 }
               }
             }
@@ -823,459 +852,466 @@
       }
     }
   },
-  "components" : {
-    "schemas" : {
-      "ChangePasswordRequest" : {
-        "type" : "object",
-        "properties" : {
-          "newPassword" : {
-            "type" : "string",
-            "maxLength" : 32,
-            "minLength" : 4
+  "components": {
+    "schemas": {
+      "ChangePasswordRequest": {
+        "type": "object",
+        "properties": {
+          "newPassword": {
+            "type": "string",
+            "maxLength": 32,
+            "minLength": 4
           }
         },
-        "required" : [ "newPassword" ]
+        "required": ["newPassword"]
       },
-      "AggregateReferenceUserAccountLong" : {
-        "type" : "object",
-        "properties" : {
-          "id" : {
-            "type" : "integer",
-            "format" : "int64"
+      "AggregateReferenceUserAccountLong": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
           }
         }
       },
-      "EntityMetaData" : {
-        "type" : "object",
-        "properties" : {
-          "createdAt" : {
-            "type" : "string",
-            "format" : "date-time"
+      "EntityMetaData": {
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
           },
-          "createdBy" : {
-            "type" : "string"
+          "createdBy": {
+            "type": "string"
           },
-          "lastModifiedAt" : {
-            "type" : "string",
-            "format" : "date-time"
+          "lastModifiedAt": {
+            "type": "string",
+            "format": "date-time"
           },
-          "lastModifiedBy" : {
-            "type" : "string"
+          "lastModifiedBy": {
+            "type": "string"
           }
         },
-        "required" : [ "createdAt", "createdBy", "lastModifiedAt", "lastModifiedBy" ]
+        "required": [
+          "createdAt",
+          "createdBy",
+          "lastModifiedAt",
+          "lastModifiedBy"
+        ]
       },
-      "UserAccount" : {
-        "type" : "object",
-        "properties" : {
-          "username" : {
-            "type" : "string"
+      "UserAccount": {
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "string"
           },
-          "firstName" : {
-            "type" : "string"
+          "firstName": {
+            "type": "string"
           },
-          "lastName" : {
-            "type" : "string"
+          "lastName": {
+            "type": "string"
           },
-          "roles" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string",
-              "enum" : [ "USER", "ADMIN", "KLEIDERWART" ]
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["USER", "ADMIN", "KLEIDERWART"]
             }
           },
-          "enabled" : {
-            "type" : "boolean"
+          "enabled": {
+            "type": "boolean"
           },
-          "id" : {
-            "type" : "integer",
-            "format" : "int64"
+          "id": {
+            "type": "integer",
+            "format": "int64"
           },
-          "metaData" : {
-            "$ref" : "#/components/schemas/EntityMetaData"
+          "metaData": {
+            "$ref": "#/components/schemas/EntityMetaData"
           },
-          "idAsReference" : {
-            "$ref" : "#/components/schemas/AggregateReferenceUserAccountLong"
+          "idAsReference": {
+            "$ref": "#/components/schemas/AggregateReferenceUserAccountLong"
           }
         },
-        "required" : [ "enabled", "firstName", "id", "idAsReference", "lastName", "metaData", "roles", "username" ]
+        "required": [
+          "enabled",
+          "firstName",
+          "id",
+          "idAsReference",
+          "lastName",
+          "metaData",
+          "roles",
+          "username"
+        ]
       },
-      "InitialAdminSetupRequest" : {
-        "type" : "object",
-        "properties" : {
-          "username" : {
-            "type" : "string",
-            "minLength" : 1
+      "InitialAdminSetupRequest": {
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "string",
+            "minLength": 1
           },
-          "password" : {
-            "type" : "string",
-            "maxLength" : 32,
-            "minLength" : 4
+          "password": {
+            "type": "string",
+            "maxLength": 32,
+            "minLength": 4
           },
-          "firstName" : {
-            "type" : "string",
-            "maxLength" : 100,
-            "minLength" : 0
+          "firstName": {
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 0
           },
-          "lastName" : {
-            "type" : "string",
-            "maxLength" : 100,
-            "minLength" : 0
+          "lastName": {
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 0
           }
         },
-        "required" : [ "firstName", "lastName", "password", "username" ]
+        "required": ["firstName", "lastName", "password", "username"]
       },
-      "LoginRequest" : {
-        "type" : "object",
-        "properties" : {
-          "username" : {
-            "type" : "string",
-            "minLength" : 1
+      "LoginRequest": {
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "string",
+            "minLength": 1
           },
-          "password" : {
-            "type" : "string",
-            "minLength" : 1
+          "password": {
+            "type": "string",
+            "minLength": 1
           },
-          "rememberMe" : {
-            "type" : "boolean"
+          "rememberMe": {
+            "type": "boolean"
           }
         },
-        "required" : [ "password", "rememberMe", "username" ]
+        "required": ["password", "rememberMe", "username"]
       },
-      "CreateOrUpdateClothingTypeRequest" : {
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string",
-            "maxLength" : 255,
-            "minLength" : 0
+      "CreateOrUpdateClothingTypeRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 0
           }
         },
-        "required" : [ "name" ]
+        "required": ["name"]
       },
-      "AggregateReferenceClothingTypeLong" : {
-        "type" : "object",
-        "properties" : {
-          "id" : {
-            "type" : "integer",
-            "format" : "int64"
+      "AggregateReferenceClothingTypeLong": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
           }
         }
       },
-      "ClothingType" : {
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string"
+      "ClothingType": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
           },
-          "id" : {
-            "type" : "integer",
-            "format" : "int64"
+          "id": {
+            "type": "integer",
+            "format": "int64"
           },
-          "metaData" : {
-            "$ref" : "#/components/schemas/EntityMetaData"
+          "metaData": {
+            "$ref": "#/components/schemas/EntityMetaData"
           },
-          "idAsReference" : {
-            "$ref" : "#/components/schemas/AggregateReferenceClothingTypeLong"
+          "idAsReference": {
+            "$ref": "#/components/schemas/AggregateReferenceClothingTypeLong"
           }
         },
-        "required" : [ "id", "idAsReference", "metaData", "name" ]
+        "required": ["id", "idAsReference", "metaData", "name"]
       },
-      "CreateClothingLocationRequest" : {
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string",
-            "maxLength" : 255,
-            "minLength" : 0
+      "CreateClothingLocationRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 0
           },
-          "comment" : {
-            "type" : "string",
-            "maxLength" : 255,
-            "minLength" : 0
+          "comment": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 0
           },
-          "onlyVisibleForKleiderwart" : {
-            "type" : "boolean"
+          "onlyVisibleForKleiderwart": {
+            "type": "boolean"
           },
-          "type" : {
-            "type" : "string",
-            "enum" : [ "POOL", "WAESCHE", "PERSONAL", "OTHER" ]
+          "type": {
+            "type": "string",
+            "enum": ["POOL", "WAESCHE", "PERSONAL", "OTHER"]
           }
         },
-        "required" : [ "comment", "name", "onlyVisibleForKleiderwart", "type" ]
+        "required": ["comment", "name", "onlyVisibleForKleiderwart", "type"]
       },
-      "AggregateReferenceClothingLocationLong" : {
-        "type" : "object",
-        "properties" : {
-          "id" : {
-            "type" : "integer",
-            "format" : "int64"
+      "AggregateReferenceClothingLocationLong": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
           }
         }
       },
-      "ClothingLocation" : {
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string"
+      "ClothingLocation": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
           },
-          "comment" : {
-            "type" : "string"
+          "comment": {
+            "type": "string"
           },
-          "onlyVisibleForKleiderwart" : {
-            "type" : "boolean"
+          "onlyVisibleForKleiderwart": {
+            "type": "boolean"
           },
-          "type" : {
-            "type" : "string",
-            "enum" : [ "POOL", "WAESCHE", "PERSONAL", "OTHER" ]
+          "type": {
+            "type": "string",
+            "enum": ["POOL", "WAESCHE", "PERSONAL", "OTHER"]
           },
-          "id" : {
-            "type" : "integer",
-            "format" : "int64"
+          "id": {
+            "type": "integer",
+            "format": "int64"
           },
-          "metaData" : {
-            "$ref" : "#/components/schemas/EntityMetaData"
+          "metaData": {
+            "$ref": "#/components/schemas/EntityMetaData"
           },
-          "idAsReference" : {
-            "$ref" : "#/components/schemas/AggregateReferenceClothingLocationLong"
+          "idAsReference": {
+            "$ref": "#/components/schemas/AggregateReferenceClothingLocationLong"
           }
         },
-        "required" : [ "comment", "id", "idAsReference", "metaData", "name", "onlyVisibleForKleiderwart", "type" ]
+        "required": [
+          "comment",
+          "id",
+          "idAsReference",
+          "metaData",
+          "name",
+          "onlyVisibleForKleiderwart",
+          "type"
+        ]
       },
-      "BatchCreateClothingLocationsRequest" : {
-        "type" : "object",
-        "properties" : {
-          "items" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/CreateClothingLocationRequest"
+      "BatchCreateClothingLocationsRequest": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CreateClothingLocationRequest"
             }
           }
         },
-        "required" : [ "items" ]
+        "required": ["items"]
       },
-      "CreateOrUpdateClothingItemRequest" : {
-        "type" : "object",
-        "properties" : {
-          "typeId" : {
-            "type" : "integer",
-            "format" : "int64"
+      "CreateOrUpdateClothingItemRequest": {
+        "type": "object",
+        "properties": {
+          "typeId": {
+            "type": "integer",
+            "format": "int64"
           },
-          "size" : {
-            "type" : "string",
-            "maxLength" : 255,
-            "minLength" : 0
+          "size": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 0
           },
-          "barcode" : {
-            "type" : "string",
-            "maxLength" : 255,
-            "minLength" : 0
+          "barcode": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 0
           },
-          "locationId" : {
-            "type" : "integer",
-            "format" : "int64"
+          "locationId": {
+            "type": "integer",
+            "format": "int64"
           }
         },
-        "required" : [ "size", "typeId" ]
+        "required": ["size", "typeId"]
       },
-      "AggregateReferenceClothingItemLong" : {
-        "type" : "object",
-        "properties" : {
-          "id" : {
-            "type" : "integer",
-            "format" : "int64"
+      "AggregateReferenceClothingItemLong": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
           }
         }
       },
-      "ClothingItem" : {
-        "type" : "object",
-        "properties" : {
-          "typeId" : {
-            "type" : "integer",
-            "format" : "int64"
+      "ClothingItem": {
+        "type": "object",
+        "properties": {
+          "typeId": {
+            "type": "integer",
+            "format": "int64"
           },
-          "size" : {
-            "type" : "string"
+          "size": {
+            "type": "string"
           },
-          "barcode" : {
-            "type" : "string"
+          "barcode": {
+            "type": "string"
           },
-          "locationId" : {
-            "type" : "integer",
-            "format" : "int64"
+          "locationId": {
+            "type": "integer",
+            "format": "int64"
           },
-          "id" : {
-            "type" : "integer",
-            "format" : "int64"
+          "id": {
+            "type": "integer",
+            "format": "int64"
           },
-          "metaData" : {
-            "$ref" : "#/components/schemas/EntityMetaData"
+          "metaData": {
+            "$ref": "#/components/schemas/EntityMetaData"
           },
-          "idAsReference" : {
-            "$ref" : "#/components/schemas/AggregateReferenceClothingItemLong"
+          "idAsReference": {
+            "$ref": "#/components/schemas/AggregateReferenceClothingItemLong"
           }
         },
-        "required" : [ "id", "idAsReference", "metaData", "size", "typeId" ]
+        "required": ["id", "idAsReference", "metaData", "size", "typeId"]
       },
-      "BatchCreateClothingItemsRequest" : {
-        "type" : "object",
-        "properties" : {
-          "items" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/CreateOrUpdateClothingItemRequest"
+      "BatchCreateClothingItemsRequest": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CreateOrUpdateClothingItemRequest"
             }
           }
         },
-        "required" : [ "items" ]
+        "required": ["items"]
       },
-      "CreateUserRequest" : {
-        "type" : "object",
-        "properties" : {
-          "username" : {
-            "type" : "string",
-            "minLength" : 1
+      "CreateUserRequest": {
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "string",
+            "minLength": 1
           },
-          "password" : {
-            "type" : "string",
-            "maxLength" : 32,
-            "minLength" : 4
+          "password": {
+            "type": "string",
+            "maxLength": 32,
+            "minLength": 4
           },
-          "firstName" : {
-            "type" : "string",
-            "maxLength" : 100,
-            "minLength" : 0
+          "firstName": {
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 0
           },
-          "lastName" : {
-            "type" : "string",
-            "maxLength" : 100,
-            "minLength" : 0
+          "lastName": {
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 0
           },
-          "roles" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string",
-              "enum" : [ "USER", "ADMIN", "KLEIDERWART" ]
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["USER", "ADMIN", "KLEIDERWART"]
             }
           }
         },
-        "required" : [ "firstName", "lastName", "password", "roles", "username" ]
+        "required": ["firstName", "lastName", "password", "roles", "username"]
       },
-      "UpdateUserRequest" : {
-        "type" : "object",
-        "properties" : {
-          "firstName" : {
-            "type" : "string",
-            "maxLength" : 100,
-            "minLength" : 0
+      "UpdateUserRequest": {
+        "type": "object",
+        "properties": {
+          "firstName": {
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 0
           },
-          "lastName" : {
-            "type" : "string",
-            "maxLength" : 100,
-            "minLength" : 0
+          "lastName": {
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 0
           },
-          "roles" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string",
-              "enum" : [ "USER", "ADMIN", "KLEIDERWART" ]
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["USER", "ADMIN", "KLEIDERWART"]
             }
           }
         },
-        "required" : [ "firstName", "lastName", "roles" ]
+        "required": ["firstName", "lastName", "roles"]
       },
-      "AuthStateResponse" : {
-        "type" : "object",
-        "properties" : {
-          "authenticated" : {
-            "type" : "boolean"
+      "AuthStateResponse": {
+        "type": "object",
+        "properties": {
+          "authenticated": {
+            "type": "boolean"
           },
-          "user" : {
-            "$ref" : "#/components/schemas/UserAccount"
+          "user": {
+            "$ref": "#/components/schemas/UserAccount"
           }
         },
-        "required" : [ "authenticated" ]
+        "required": ["authenticated"]
       },
-      "ClothingTypeSummary" : {
-        "type" : "object",
-        "properties" : {
-          "typeId" : {
-            "type" : "integer",
-            "format" : "int64"
+      "ClothingTypeSummary": {
+        "type": "object",
+        "properties": {
+          "typeId": {
+            "type": "integer",
+            "format": "int64"
           },
-          "typeName" : {
-            "type" : "string"
+          "typeName": {
+            "type": "string"
           },
-          "sizeCounts" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/SizeSummary"
+          "sizeCounts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SizeSummary"
             }
           }
         },
-        "required" : [ "sizeCounts", "typeId", "typeName" ]
+        "required": ["sizeCounts", "typeId", "typeName"]
       },
-      "SizeSummary" : {
-        "type" : "object",
-        "properties" : {
-          "size" : {
-            "type" : "string"
+      "SizeSummary": {
+        "type": "object",
+        "properties": {
+          "size": {
+            "type": "string"
           },
-          "count" : {
-            "type" : "integer",
-            "format" : "int32"
+          "count": {
+            "type": "integer",
+            "format": "int32"
           }
         },
-        "required" : [ "count", "size" ]
+        "required": ["count", "size"]
       },
-      "ClothingLocationSummary" : {
-        "type" : "object",
-        "properties" : {
-          "locationId" : {
-            "type" : "integer",
-            "format" : "int64"
+      "ClothingLocationSummary": {
+        "type": "object",
+        "properties": {
+          "locationId": {
+            "type": "integer",
+            "format": "int64"
           },
-          "locationName" : {
-            "type" : "string"
+          "locationName": {
+            "type": "string"
           },
-          "types" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/ClothingTypeSummary"
+          "types": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ClothingTypeSummary"
             }
           }
         },
-        "required" : [ "locationId", "locationName", "types" ]
+        "required": ["locationId", "locationName", "types"]
       },
-      "ResolvedClothingItem" : {
-        "type" : "object",
-        "properties" : {
-          "id" : {
-            "type" : "integer",
-            "format" : "int64"
+      "ResolvedClothingItem": {
+        "type": "object",
+        "properties": {
+          "clothingItem": {
+            "$ref": "#/components/schemas/ClothingItem"
           },
-          "barcode" : {
-            "type" : "string"
+          "location": {
+            "$ref": "#/components/schemas/ClothingLocation"
           },
-          "typeName" : {
-            "type" : "string"
-          },
-          "size" : {
-            "type" : "string"
-          },
-          "currentLocationId" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "currentLocationName" : {
-            "type" : "string"
-          },
-          "currentLocationType" : {
-            "type" : "string",
-            "enum" : [ "POOL", "WAESCHE", "PERSONAL", "OTHER" ]
+          "clothingType": {
+            "$ref": "#/components/schemas/ClothingType"
           }
         },
-        "required" : [ "id", "size", "typeName" ]
+        "required": ["clothingItem", "clothingType"]
       }
     }
   }

--- a/server/src/main/resources/open-api-contract.json
+++ b/server/src/main/resources/open-api-contract.json
@@ -1,43 +1,41 @@
 {
-  "openapi": "3.1.0",
-  "info": {
-    "title": "OpenAPI definition",
-    "version": "v0"
+  "openapi" : "3.1.0",
+  "info" : {
+    "title" : "OpenAPI definition",
+    "version" : "v0"
   },
-  "paths": {
-    "/api/admin/users/{id}/password": {
-      "put": {
-        "tags": ["admin-user-controller"],
-        "operationId": "changePassword",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "exclusiveMinimum": 0
-            }
+  "paths" : {
+    "/api/admin/users/{id}/password" : {
+      "put" : {
+        "tags" : [ "admin-user-controller" ],
+        "operationId" : "changePassword",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64",
+            "exclusiveMinimum" : 0
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ChangePasswordRequest"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ChangePasswordRequest"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserAccount"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UserAccount"
                 }
               }
             }
@@ -45,27 +43,27 @@
         }
       }
     },
-    "/api/public/setup/initial-admin": {
-      "post": {
-        "tags": ["initial-setup-controller"],
-        "operationId": "initializeAdmin",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/InitialAdminSetupRequest"
+    "/api/public/setup/initial-admin" : {
+      "post" : {
+        "tags" : [ "initial-setup-controller" ],
+        "operationId" : "initializeAdmin",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/InitialAdminSetupRequest"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserAccount"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UserAccount"
                 }
               }
             }
@@ -73,54 +71,54 @@
         }
       }
     },
-    "/api/public/auth/logout": {
-      "post": {
-        "tags": ["auth-controller"],
-        "operationId": "logout",
-        "responses": {
-          "204": {
-            "description": "No Content",
-            "content": {}
+    "/api/public/auth/logout" : {
+      "post" : {
+        "tags" : [ "auth-controller" ],
+        "operationId" : "logout",
+        "responses" : {
+          "204" : {
+            "description" : "No Content",
+            "content" : { }
           }
         }
       }
     },
-    "/api/public/auth/login": {
-      "post": {
-        "tags": ["auth-controller"],
-        "operationId": "login",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/LoginRequest"
+    "/api/public/auth/login" : {
+      "post" : {
+        "tags" : [ "auth-controller" ],
+        "operationId" : "login",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/LoginRequest"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {}
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : { }
           }
         }
       }
     },
-    "/api/clothing/types": {
-      "get": {
-        "tags": ["clothing-type-controller"],
-        "summary": "List all protective clothing types",
-        "operationId": "getAllTypes",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ClothingType"
+    "/api/clothing/types" : {
+      "get" : {
+        "tags" : [ "clothing-type-controller" ],
+        "summary" : "List all protective clothing types",
+        "operationId" : "getAllTypes",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ClothingType"
                   }
                 }
               }
@@ -128,27 +126,27 @@
           }
         }
       },
-      "post": {
-        "tags": ["clothing-type-controller"],
-        "summary": "Create a new protective clothing type",
-        "operationId": "createType",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateOrUpdateClothingTypeRequest"
+      "post" : {
+        "tags" : [ "clothing-type-controller" ],
+        "summary" : "Create a new protective clothing type",
+        "operationId" : "createType",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/CreateOrUpdateClothingTypeRequest"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ClothingType"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ClothingType"
                 }
               }
             }
@@ -156,20 +154,20 @@
         }
       }
     },
-    "/api/clothing/locations": {
-      "get": {
-        "tags": ["clothing-location-controller"],
-        "summary": "List all clothing locations",
-        "operationId": "getAllLocations",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ClothingLocation"
+    "/api/clothing/locations" : {
+      "get" : {
+        "tags" : [ "clothing-location-controller" ],
+        "summary" : "List all clothing locations",
+        "operationId" : "getAllLocations",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ClothingLocation"
                   }
                 }
               }
@@ -177,27 +175,27 @@
           }
         }
       },
-      "post": {
-        "tags": ["clothing-location-controller"],
-        "summary": "Create a new clothing location",
-        "operationId": "createLocation",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateClothingLocationRequest"
+      "post" : {
+        "tags" : [ "clothing-location-controller" ],
+        "summary" : "Create a new clothing location",
+        "operationId" : "createLocation",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/CreateClothingLocationRequest"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ClothingLocation"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ClothingLocation"
                 }
               }
             }
@@ -205,111 +203,30 @@
         }
       }
     },
-    "/api/clothing/locations/batch": {
-      "post": {
-        "tags": ["clothing-location-controller"],
-        "summary": "Create multiple clothing locations in a single request",
-        "operationId": "createBatchLocations",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BatchCreateClothingLocationsRequest"
+    "/api/clothing/locations/batch" : {
+      "post" : {
+        "tags" : [ "clothing-location-controller" ],
+        "summary" : "Create multiple clothing locations in a single request",
+        "operationId" : "createBatchLocations",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchCreateClothingLocationsRequest"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ClothingLocation"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/clothing/items": {
-      "get": {
-        "tags": ["clothing-item-controller"],
-        "summary": "List all clothing items",
-        "operationId": "getAllItems",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ClothingItem"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": ["clothing-item-controller"],
-        "summary": "Create a new clothing item",
-        "operationId": "createItem",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateOrUpdateClothingItemRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ClothingItem"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/clothing/items/batch": {
-      "post": {
-        "tags": ["clothing-item-controller"],
-        "summary": "Create multiple clothing items in a single request",
-        "operationId": "createBatchItems",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BatchCreateClothingItemsRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ClothingItem"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ClothingLocation"
                   }
                 }
               }
@@ -318,19 +235,20 @@
         }
       }
     },
-    "/api/admin/users": {
-      "get": {
-        "tags": ["admin-user-controller"],
-        "operationId": "getAllUsers",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/UserAccount"
+    "/api/clothing/items" : {
+      "get" : {
+        "tags" : [ "clothing-item-controller" ],
+        "summary" : "List all clothing items",
+        "operationId" : "getAllItems",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ClothingItem"
                   }
                 }
               }
@@ -338,26 +256,27 @@
           }
         }
       },
-      "post": {
-        "tags": ["admin-user-controller"],
-        "operationId": "createUser",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateUserRequest"
+      "post" : {
+        "tags" : [ "clothing-item-controller" ],
+        "summary" : "Create a new clothing item",
+        "operationId" : "createItem",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/CreateOrUpdateClothingItemRequest"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserAccount"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ClothingItem"
                 }
               }
             }
@@ -365,391 +284,30 @@
         }
       }
     },
-    "/api/clothing/types/{id}": {
-      "get": {
-        "tags": ["clothing-type-controller"],
-        "summary": "Get a protective clothing type by ID",
-        "operationId": "getTypeById",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "ID of the protective clothing type",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "exclusiveMinimum": 0
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ClothingType"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": ["clothing-type-controller"],
-        "summary": "Delete a protective clothing type",
-        "operationId": "deleteType",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "ID of the protective clothing type",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "exclusiveMinimum": 0
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          }
-        }
-      },
-      "patch": {
-        "tags": ["clothing-type-controller"],
-        "summary": "Update a protective clothing type",
-        "operationId": "updateType",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "ID of the protective clothing type",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "exclusiveMinimum": 0
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateOrUpdateClothingTypeRequest"
+    "/api/clothing/items/batch" : {
+      "post" : {
+        "tags" : [ "clothing-item-controller" ],
+        "summary" : "Create multiple clothing items in a single request",
+        "operationId" : "createBatchItems",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchCreateClothingItemsRequest"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ClothingType"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/clothing/locations/{id}": {
-      "get": {
-        "tags": ["clothing-location-controller"],
-        "summary": "Get a clothing location by ID",
-        "operationId": "getLocationById",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "ID of the clothing location",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "exclusiveMinimum": 0
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ClothingLocation"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": ["clothing-location-controller"],
-        "summary": "Delete a clothing location",
-        "operationId": "deleteLocation",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "ID of the clothing location",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "exclusiveMinimum": 0
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          }
-        }
-      },
-      "patch": {
-        "tags": ["clothing-location-controller"],
-        "summary": "Update a clothing location",
-        "operationId": "updateLocation",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "ID of the clothing location",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "exclusiveMinimum": 0
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateClothingLocationRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ClothingLocation"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/clothing/items/{id}": {
-      "get": {
-        "tags": ["clothing-item-controller"],
-        "summary": "Get a clothing item by ID",
-        "operationId": "getItemById",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "ID of the clothing item",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "exclusiveMinimum": 0
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ClothingItem"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": ["clothing-item-controller"],
-        "summary": "Delete a clothing item",
-        "operationId": "deleteItem",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "ID of the clothing item",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "exclusiveMinimum": 0
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          }
-        }
-      },
-      "patch": {
-        "tags": ["clothing-item-controller"],
-        "summary": "Update a clothing item",
-        "operationId": "updateItem",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "ID of the clothing item",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "exclusiveMinimum": 0
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateOrUpdateClothingItemRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ClothingItem"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/admin/users/{id}": {
-      "get": {
-        "tags": ["admin-user-controller"],
-        "operationId": "getUserById",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "exclusiveMinimum": 0
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserAccount"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "tags": ["admin-user-controller"],
-        "operationId": "updateUser",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "exclusiveMinimum": 0
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateUserRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserAccount"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/public/auth/me": {
-      "get": {
-        "tags": ["auth-controller"],
-        "operationId": "me",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthStateResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/clothing/overview/summary/type": {
-      "get": {
-        "tags": ["clothing-overview-controller"],
-        "summary": "List clothing item counts by type and size",
-        "operationId": "getSummariesByType",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ClothingTypeSummary"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ClothingItem"
                   }
                 }
               }
@@ -758,21 +316,505 @@
         }
       }
     },
-    "/api/clothing/overview/dashboard/location": {
-      "get": {
-        "tags": ["clothing-overview-controller"],
-        "summary": "Get clothing availability overview for dashboard locations",
-        "operationId": "getDashboardLocationSummaries",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ClothingLocationSummary"
+    "/api/admin/users" : {
+      "get" : {
+        "tags" : [ "admin-user-controller" ],
+        "operationId" : "getAllUsers",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/UserAccount"
                   }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "admin-user-controller" ],
+        "operationId" : "createUser",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/CreateUserRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UserAccount"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/clothing/types/{id}" : {
+      "get" : {
+        "tags" : [ "clothing-type-controller" ],
+        "summary" : "Get a protective clothing type by ID",
+        "operationId" : "getTypeById",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "description" : "ID of the protective clothing type",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64",
+            "exclusiveMinimum" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ClothingType"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "clothing-type-controller" ],
+        "summary" : "Delete a protective clothing type",
+        "operationId" : "deleteType",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "description" : "ID of the protective clothing type",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64",
+            "exclusiveMinimum" : 0
+          }
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "No Content"
+          }
+        }
+      },
+      "patch" : {
+        "tags" : [ "clothing-type-controller" ],
+        "summary" : "Update a protective clothing type",
+        "operationId" : "updateType",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "description" : "ID of the protective clothing type",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64",
+            "exclusiveMinimum" : 0
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/CreateOrUpdateClothingTypeRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ClothingType"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/clothing/locations/{id}" : {
+      "get" : {
+        "tags" : [ "clothing-location-controller" ],
+        "summary" : "Get a clothing location by ID",
+        "operationId" : "getLocationById",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "description" : "ID of the clothing location",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64",
+            "exclusiveMinimum" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ClothingLocation"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "clothing-location-controller" ],
+        "summary" : "Delete a clothing location",
+        "operationId" : "deleteLocation",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "description" : "ID of the clothing location",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64",
+            "exclusiveMinimum" : 0
+          }
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "No Content"
+          }
+        }
+      },
+      "patch" : {
+        "tags" : [ "clothing-location-controller" ],
+        "summary" : "Update a clothing location",
+        "operationId" : "updateLocation",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "description" : "ID of the clothing location",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64",
+            "exclusiveMinimum" : 0
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/CreateClothingLocationRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ClothingLocation"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/clothing/items/{id}" : {
+      "get" : {
+        "tags" : [ "clothing-item-controller" ],
+        "summary" : "Get a clothing item by ID",
+        "operationId" : "getItemById",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "description" : "ID of the clothing item",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64",
+            "exclusiveMinimum" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ClothingItem"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "clothing-item-controller" ],
+        "summary" : "Delete a clothing item",
+        "operationId" : "deleteItem",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "description" : "ID of the clothing item",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64",
+            "exclusiveMinimum" : 0
+          }
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "No Content"
+          }
+        }
+      },
+      "patch" : {
+        "tags" : [ "clothing-item-controller" ],
+        "summary" : "Update a clothing item",
+        "operationId" : "updateItem",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "description" : "ID of the clothing item",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64",
+            "exclusiveMinimum" : 0
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/CreateOrUpdateClothingItemRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ClothingItem"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/users/{id}" : {
+      "get" : {
+        "tags" : [ "admin-user-controller" ],
+        "operationId" : "getUserById",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64",
+            "exclusiveMinimum" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UserAccount"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch" : {
+        "tags" : [ "admin-user-controller" ],
+        "operationId" : "updateUser",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64",
+            "exclusiveMinimum" : 0
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/UpdateUserRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UserAccount"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/auth/me" : {
+      "get" : {
+        "tags" : [ "auth-controller" ],
+        "operationId" : "me",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AuthStateResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/clothing/overview/summary/type" : {
+      "get" : {
+        "tags" : [ "clothing-overview-controller" ],
+        "summary" : "List clothing item counts by type and size",
+        "operationId" : "getSummariesByType",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ClothingTypeSummary"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/clothing/overview/dashboard/location" : {
+      "get" : {
+        "tags" : [ "clothing-overview-controller" ],
+        "summary" : "Get clothing availability overview for dashboard locations",
+        "operationId" : "getDashboardLocationSummaries",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ClothingLocationSummary"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/clothing/items/search" : {
+      "get" : {
+        "tags" : [ "clothing-item-controller" ],
+        "summary" : "Search clothing items by type name, size, or barcode",
+        "operationId" : "searchItems",
+        "parameters" : [ {
+          "name" : "q",
+          "in" : "query",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 50
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ResolvedClothingItem"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/clothing/items/by-barcode/{barcode}" : {
+      "get" : {
+        "tags" : [ "clothing-item-controller" ],
+        "summary" : "Look up a clothing item by barcode",
+        "operationId" : "getItemByBarcode",
+        "parameters" : [ {
+          "name" : "barcode",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ResolvedClothingItem"
                 }
               }
             }
@@ -781,451 +823,459 @@
       }
     }
   },
-  "components": {
-    "schemas": {
-      "ChangePasswordRequest": {
-        "type": "object",
-        "properties": {
-          "newPassword": {
-            "type": "string",
-            "maxLength": 32,
-            "minLength": 4
+  "components" : {
+    "schemas" : {
+      "ChangePasswordRequest" : {
+        "type" : "object",
+        "properties" : {
+          "newPassword" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "minLength" : 4
           }
         },
-        "required": ["newPassword"]
+        "required" : [ "newPassword" ]
       },
-      "AggregateReferenceUserAccountLong": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int64"
+      "AggregateReferenceUserAccountLong" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
           }
         }
       },
-      "EntityMetaData": {
-        "type": "object",
-        "properties": {
-          "createdAt": {
-            "type": "string",
-            "format": "date-time"
+      "EntityMetaData" : {
+        "type" : "object",
+        "properties" : {
+          "createdAt" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "createdBy": {
-            "type": "string"
+          "createdBy" : {
+            "type" : "string"
           },
-          "lastModifiedAt": {
-            "type": "string",
-            "format": "date-time"
+          "lastModifiedAt" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "lastModifiedBy": {
-            "type": "string"
+          "lastModifiedBy" : {
+            "type" : "string"
           }
         },
-        "required": [
-          "createdAt",
-          "createdBy",
-          "lastModifiedAt",
-          "lastModifiedBy"
-        ]
+        "required" : [ "createdAt", "createdBy", "lastModifiedAt", "lastModifiedBy" ]
       },
-      "UserAccount": {
-        "type": "object",
-        "properties": {
-          "username": {
-            "type": "string"
+      "UserAccount" : {
+        "type" : "object",
+        "properties" : {
+          "username" : {
+            "type" : "string"
           },
-          "firstName": {
-            "type": "string"
+          "firstName" : {
+            "type" : "string"
           },
-          "lastName": {
-            "type": "string"
+          "lastName" : {
+            "type" : "string"
           },
-          "roles": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "enum": ["USER", "ADMIN", "KLEIDERWART"]
+          "roles" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "enum" : [ "USER", "ADMIN", "KLEIDERWART" ]
             }
           },
-          "enabled": {
-            "type": "boolean"
+          "enabled" : {
+            "type" : "boolean"
           },
-          "id": {
-            "type": "integer",
-            "format": "int64"
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "metaData": {
-            "$ref": "#/components/schemas/EntityMetaData"
+          "metaData" : {
+            "$ref" : "#/components/schemas/EntityMetaData"
           },
-          "idAsReference": {
-            "$ref": "#/components/schemas/AggregateReferenceUserAccountLong"
+          "idAsReference" : {
+            "$ref" : "#/components/schemas/AggregateReferenceUserAccountLong"
           }
         },
-        "required": [
-          "enabled",
-          "firstName",
-          "id",
-          "idAsReference",
-          "lastName",
-          "metaData",
-          "roles",
-          "username"
-        ]
+        "required" : [ "enabled", "firstName", "id", "idAsReference", "lastName", "metaData", "roles", "username" ]
       },
-      "InitialAdminSetupRequest": {
-        "type": "object",
-        "properties": {
-          "username": {
-            "type": "string",
-            "minLength": 1
+      "InitialAdminSetupRequest" : {
+        "type" : "object",
+        "properties" : {
+          "username" : {
+            "type" : "string",
+            "minLength" : 1
           },
-          "password": {
-            "type": "string",
-            "maxLength": 32,
-            "minLength": 4
+          "password" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "minLength" : 4
           },
-          "firstName": {
-            "type": "string",
-            "maxLength": 100,
-            "minLength": 0
+          "firstName" : {
+            "type" : "string",
+            "maxLength" : 100,
+            "minLength" : 0
           },
-          "lastName": {
-            "type": "string",
-            "maxLength": 100,
-            "minLength": 0
+          "lastName" : {
+            "type" : "string",
+            "maxLength" : 100,
+            "minLength" : 0
           }
         },
-        "required": ["firstName", "lastName", "password", "username"]
+        "required" : [ "firstName", "lastName", "password", "username" ]
       },
-      "LoginRequest": {
-        "type": "object",
-        "properties": {
-          "username": {
-            "type": "string",
-            "minLength": 1
+      "LoginRequest" : {
+        "type" : "object",
+        "properties" : {
+          "username" : {
+            "type" : "string",
+            "minLength" : 1
           },
-          "password": {
-            "type": "string",
-            "minLength": 1
+          "password" : {
+            "type" : "string",
+            "minLength" : 1
           },
-          "rememberMe": {
-            "type": "boolean"
+          "rememberMe" : {
+            "type" : "boolean"
           }
         },
-        "required": ["password", "rememberMe", "username"]
+        "required" : [ "password", "rememberMe", "username" ]
       },
-      "CreateOrUpdateClothingTypeRequest": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "maxLength": 255,
-            "minLength": 0
+      "CreateOrUpdateClothingTypeRequest" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "maxLength" : 255,
+            "minLength" : 0
           }
         },
-        "required": ["name"]
+        "required" : [ "name" ]
       },
-      "AggregateReferenceClothingTypeLong": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int64"
+      "AggregateReferenceClothingTypeLong" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
           }
         }
       },
-      "ClothingType": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
+      "ClothingType" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
           },
-          "id": {
-            "type": "integer",
-            "format": "int64"
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "metaData": {
-            "$ref": "#/components/schemas/EntityMetaData"
+          "metaData" : {
+            "$ref" : "#/components/schemas/EntityMetaData"
           },
-          "idAsReference": {
-            "$ref": "#/components/schemas/AggregateReferenceClothingTypeLong"
+          "idAsReference" : {
+            "$ref" : "#/components/schemas/AggregateReferenceClothingTypeLong"
           }
         },
-        "required": ["id", "idAsReference", "metaData", "name"]
+        "required" : [ "id", "idAsReference", "metaData", "name" ]
       },
-      "CreateClothingLocationRequest": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "maxLength": 255,
-            "minLength": 0
+      "CreateClothingLocationRequest" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "maxLength" : 255,
+            "minLength" : 0
           },
-          "comment": {
-            "type": "string",
-            "maxLength": 255,
-            "minLength": 0
+          "comment" : {
+            "type" : "string",
+            "maxLength" : 255,
+            "minLength" : 0
           },
-          "onlyVisibleForKleiderwart": {
-            "type": "boolean"
+          "onlyVisibleForKleiderwart" : {
+            "type" : "boolean"
           },
-          "type": {
-            "type": "string",
-            "enum": ["POOL", "WAESCHE", "PERSONAL", "OTHER"]
+          "type" : {
+            "type" : "string",
+            "enum" : [ "POOL", "WAESCHE", "PERSONAL", "OTHER" ]
           }
         },
-        "required": ["comment", "name", "onlyVisibleForKleiderwart", "type"]
+        "required" : [ "comment", "name", "onlyVisibleForKleiderwart", "type" ]
       },
-      "AggregateReferenceClothingLocationLong": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int64"
+      "AggregateReferenceClothingLocationLong" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
           }
         }
       },
-      "ClothingLocation": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
+      "ClothingLocation" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
           },
-          "comment": {
-            "type": "string"
+          "comment" : {
+            "type" : "string"
           },
-          "onlyVisibleForKleiderwart": {
-            "type": "boolean"
+          "onlyVisibleForKleiderwart" : {
+            "type" : "boolean"
           },
-          "type": {
-            "type": "string",
-            "enum": ["POOL", "WAESCHE", "PERSONAL", "OTHER"]
+          "type" : {
+            "type" : "string",
+            "enum" : [ "POOL", "WAESCHE", "PERSONAL", "OTHER" ]
           },
-          "id": {
-            "type": "integer",
-            "format": "int64"
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "metaData": {
-            "$ref": "#/components/schemas/EntityMetaData"
+          "metaData" : {
+            "$ref" : "#/components/schemas/EntityMetaData"
           },
-          "idAsReference": {
-            "$ref": "#/components/schemas/AggregateReferenceClothingLocationLong"
+          "idAsReference" : {
+            "$ref" : "#/components/schemas/AggregateReferenceClothingLocationLong"
           }
         },
-        "required": [
-          "comment",
-          "id",
-          "idAsReference",
-          "metaData",
-          "name",
-          "onlyVisibleForKleiderwart",
-          "type"
-        ]
+        "required" : [ "comment", "id", "idAsReference", "metaData", "name", "onlyVisibleForKleiderwart", "type" ]
       },
-      "BatchCreateClothingLocationsRequest": {
-        "type": "object",
-        "properties": {
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CreateClothingLocationRequest"
+      "BatchCreateClothingLocationsRequest" : {
+        "type" : "object",
+        "properties" : {
+          "items" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/CreateClothingLocationRequest"
             }
           }
         },
-        "required": ["items"]
+        "required" : [ "items" ]
       },
-      "CreateOrUpdateClothingItemRequest": {
-        "type": "object",
-        "properties": {
-          "typeId": {
-            "type": "integer",
-            "format": "int64"
+      "CreateOrUpdateClothingItemRequest" : {
+        "type" : "object",
+        "properties" : {
+          "typeId" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "size": {
-            "type": "string",
-            "maxLength": 255,
-            "minLength": 0
+          "size" : {
+            "type" : "string",
+            "maxLength" : 255,
+            "minLength" : 0
           },
-          "barcode": {
-            "type": "string",
-            "maxLength": 255,
-            "minLength": 0
+          "barcode" : {
+            "type" : "string",
+            "maxLength" : 255,
+            "minLength" : 0
           },
-          "locationId": {
-            "type": "integer",
-            "format": "int64"
+          "locationId" : {
+            "type" : "integer",
+            "format" : "int64"
           }
         },
-        "required": ["size", "typeId"]
+        "required" : [ "size", "typeId" ]
       },
-      "AggregateReferenceClothingItemLong": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int64"
+      "AggregateReferenceClothingItemLong" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
           }
         }
       },
-      "ClothingItem": {
-        "type": "object",
-        "properties": {
-          "typeId": {
-            "type": "integer",
-            "format": "int64"
+      "ClothingItem" : {
+        "type" : "object",
+        "properties" : {
+          "typeId" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "size": {
-            "type": "string"
+          "size" : {
+            "type" : "string"
           },
-          "barcode": {
-            "type": "string"
+          "barcode" : {
+            "type" : "string"
           },
-          "locationId": {
-            "type": "integer",
-            "format": "int64"
+          "locationId" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "id": {
-            "type": "integer",
-            "format": "int64"
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "metaData": {
-            "$ref": "#/components/schemas/EntityMetaData"
+          "metaData" : {
+            "$ref" : "#/components/schemas/EntityMetaData"
           },
-          "idAsReference": {
-            "$ref": "#/components/schemas/AggregateReferenceClothingItemLong"
+          "idAsReference" : {
+            "$ref" : "#/components/schemas/AggregateReferenceClothingItemLong"
           }
         },
-        "required": ["id", "idAsReference", "metaData", "size", "typeId"]
+        "required" : [ "id", "idAsReference", "metaData", "size", "typeId" ]
       },
-      "BatchCreateClothingItemsRequest": {
-        "type": "object",
-        "properties": {
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CreateOrUpdateClothingItemRequest"
+      "BatchCreateClothingItemsRequest" : {
+        "type" : "object",
+        "properties" : {
+          "items" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/CreateOrUpdateClothingItemRequest"
             }
           }
         },
-        "required": ["items"]
+        "required" : [ "items" ]
       },
-      "CreateUserRequest": {
-        "type": "object",
-        "properties": {
-          "username": {
-            "type": "string",
-            "minLength": 1
+      "CreateUserRequest" : {
+        "type" : "object",
+        "properties" : {
+          "username" : {
+            "type" : "string",
+            "minLength" : 1
           },
-          "password": {
-            "type": "string",
-            "maxLength": 32,
-            "minLength": 4
+          "password" : {
+            "type" : "string",
+            "maxLength" : 32,
+            "minLength" : 4
           },
-          "firstName": {
-            "type": "string",
-            "maxLength": 100,
-            "minLength": 0
+          "firstName" : {
+            "type" : "string",
+            "maxLength" : 100,
+            "minLength" : 0
           },
-          "lastName": {
-            "type": "string",
-            "maxLength": 100,
-            "minLength": 0
+          "lastName" : {
+            "type" : "string",
+            "maxLength" : 100,
+            "minLength" : 0
           },
-          "roles": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "enum": ["USER", "ADMIN", "KLEIDERWART"]
+          "roles" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "enum" : [ "USER", "ADMIN", "KLEIDERWART" ]
             }
           }
         },
-        "required": ["firstName", "lastName", "password", "roles", "username"]
+        "required" : [ "firstName", "lastName", "password", "roles", "username" ]
       },
-      "UpdateUserRequest": {
-        "type": "object",
-        "properties": {
-          "firstName": {
-            "type": "string",
-            "maxLength": 100,
-            "minLength": 0
+      "UpdateUserRequest" : {
+        "type" : "object",
+        "properties" : {
+          "firstName" : {
+            "type" : "string",
+            "maxLength" : 100,
+            "minLength" : 0
           },
-          "lastName": {
-            "type": "string",
-            "maxLength": 100,
-            "minLength": 0
+          "lastName" : {
+            "type" : "string",
+            "maxLength" : 100,
+            "minLength" : 0
           },
-          "roles": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "enum": ["USER", "ADMIN", "KLEIDERWART"]
+          "roles" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "enum" : [ "USER", "ADMIN", "KLEIDERWART" ]
             }
           }
         },
-        "required": ["firstName", "lastName", "roles"]
+        "required" : [ "firstName", "lastName", "roles" ]
       },
-      "AuthStateResponse": {
-        "type": "object",
-        "properties": {
-          "authenticated": {
-            "type": "boolean"
+      "AuthStateResponse" : {
+        "type" : "object",
+        "properties" : {
+          "authenticated" : {
+            "type" : "boolean"
           },
-          "user": {
-            "$ref": "#/components/schemas/UserAccount"
+          "user" : {
+            "$ref" : "#/components/schemas/UserAccount"
           }
         },
-        "required": ["authenticated"]
+        "required" : [ "authenticated" ]
       },
-      "ClothingTypeSummary": {
-        "type": "object",
-        "properties": {
-          "typeId": {
-            "type": "integer",
-            "format": "int64"
+      "ClothingTypeSummary" : {
+        "type" : "object",
+        "properties" : {
+          "typeId" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "typeName": {
-            "type": "string"
+          "typeName" : {
+            "type" : "string"
           },
-          "sizeCounts": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/SizeSummary"
+          "sizeCounts" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SizeSummary"
             }
           }
         },
-        "required": ["sizeCounts", "typeId", "typeName"]
+        "required" : [ "sizeCounts", "typeId", "typeName" ]
       },
-      "SizeSummary": {
-        "type": "object",
-        "properties": {
-          "size": {
-            "type": "string"
+      "SizeSummary" : {
+        "type" : "object",
+        "properties" : {
+          "size" : {
+            "type" : "string"
           },
-          "count": {
-            "type": "integer",
-            "format": "int32"
+          "count" : {
+            "type" : "integer",
+            "format" : "int32"
           }
         },
-        "required": ["count", "size"]
+        "required" : [ "count", "size" ]
       },
-      "ClothingLocationSummary": {
-        "type": "object",
-        "properties": {
-          "locationId": {
-            "type": "integer",
-            "format": "int64"
+      "ClothingLocationSummary" : {
+        "type" : "object",
+        "properties" : {
+          "locationId" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "locationName": {
-            "type": "string"
+          "locationName" : {
+            "type" : "string"
           },
-          "types": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ClothingTypeSummary"
+          "types" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ClothingTypeSummary"
             }
           }
         },
-        "required": ["locationId", "locationName", "types"]
+        "required" : [ "locationId", "locationName", "types" ]
+      },
+      "ResolvedClothingItem" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "barcode" : {
+            "type" : "string"
+          },
+          "typeName" : {
+            "type" : "string"
+          },
+          "size" : {
+            "type" : "string"
+          },
+          "currentLocationId" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "currentLocationName" : {
+            "type" : "string"
+          },
+          "currentLocationType" : {
+            "type" : "string",
+            "enum" : [ "POOL", "WAESCHE", "PERSONAL", "OTHER" ]
+          }
+        },
+        "required" : [ "id", "size", "typeName" ]
       }
     }
   }

--- a/server/src/test/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ClothingItemLookupIT.kt
+++ b/server/src/test/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ClothingItemLookupIT.kt
@@ -53,12 +53,12 @@ class ClothingItemLookupIT : IntegrationTest() {
         val response = getByBarcode(barcode, validCookieHeader)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(response.body?.barcode).isEqualTo(barcode)
-        assertThat(response.body?.typeName).isEqualTo(type.name)
-        assertThat(response.body?.size).isEqualTo("L")
-        assertThat(response.body?.currentLocationId).isEqualTo(location.id)
-        assertThat(response.body?.currentLocationName).isEqualTo(location.name)
-        assertThat(response.body?.currentLocationType).isEqualTo(LocationType.POOL)
+        assertThat(response.body?.clothingItem?.barcode).isEqualTo(barcode)
+        assertThat(response.body?.clothingType?.name).isEqualTo(type.name)
+        assertThat(response.body?.clothingItem?.size).isEqualTo("L")
+        assertThat(response.body?.location?.id).isEqualTo(location.id)
+        assertThat(response.body?.location?.name).isEqualTo(location.name)
+        assertThat(response.body?.location?.type).isEqualTo(LocationType.POOL)
     }
 
     @Test
@@ -71,7 +71,8 @@ class ClothingItemLookupIT : IntegrationTest() {
     @Test
     fun `by-barcode returns 404 for item at Kleiderwart-only location when caller is not Kleiderwart`() {
         val type = createType()
-        val restrictedLocation = createLocation(LocationType.PERSONAL, onlyVisibleForKleiderwart = true)
+        val restrictedLocation =
+            createLocation(LocationType.PERSONAL, onlyVisibleForKleiderwart = true)
         val barcode = "RESTRICTED-${System.nanoTime()}"
         itemCalls.createItem(
             CreateOrUpdateClothingItemRequest(
@@ -103,7 +104,7 @@ class ClothingItemLookupIT : IntegrationTest() {
         val response = search(uniqueName.lowercase(), validCookieHeader)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(response.body?.map { it.typeName }).contains(uniqueName)
+        assertThat(response.body?.map { it.clothingType.name }).contains(uniqueName)
     }
 
     @Test
@@ -118,7 +119,7 @@ class ClothingItemLookupIT : IntegrationTest() {
         val response = search(uniqueSize.uppercase(), validCookieHeader)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(response.body?.map { it.size }).contains(uniqueSize)
+        assertThat(response.body?.map { it.clothingItem.size }).contains(uniqueSize)
     }
 
     @Test
@@ -126,14 +127,18 @@ class ClothingItemLookupIT : IntegrationTest() {
         val type = createType()
         val uniqueBarcode = "BC-${System.nanoTime()}"
         itemCalls.createItem(
-            CreateOrUpdateClothingItemRequest(typeId = type.id, size = "S", barcode = uniqueBarcode),
+            CreateOrUpdateClothingItemRequest(
+                typeId = type.id,
+                size = "S",
+                barcode = uniqueBarcode,
+            ),
             authCookie = validCookieHeader,
         )
 
         val response = search(uniqueBarcode.lowercase(), validCookieHeader)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(response.body?.map { it.barcode }).contains(uniqueBarcode)
+        assertThat(response.body?.map { it.clothingItem.barcode }).contains(uniqueBarcode)
     }
 
     @Test
@@ -142,7 +147,10 @@ class ClothingItemLookupIT : IntegrationTest() {
         // Create 55 items to exceed the cap
         repeat(55) {
             itemCalls.createItem(
-                CreateOrUpdateClothingItemRequest(typeId = type.id, size = "CAP-TEST-${System.nanoTime()}"),
+                CreateOrUpdateClothingItemRequest(
+                    typeId = type.id,
+                    size = "CAP-TEST-${System.nanoTime()}",
+                ),
                 authCookie = validCookieHeader,
             )
         }
@@ -156,7 +164,8 @@ class ClothingItemLookupIT : IntegrationTest() {
     @Test
     fun `search filters out items at Kleiderwart-only locations for non-Kleiderwart callers`() {
         val type = createType()
-        val restrictedLocation = createLocation(LocationType.PERSONAL, onlyVisibleForKleiderwart = true)
+        val restrictedLocation =
+            createLocation(LocationType.PERSONAL, onlyVisibleForKleiderwart = true)
         val uniqueBarcode = "FILTERED-${System.nanoTime()}"
         itemCalls.createItem(
             CreateOrUpdateClothingItemRequest(
@@ -172,7 +181,7 @@ class ClothingItemLookupIT : IntegrationTest() {
         val response = search(uniqueBarcode, regularUserCookie)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(response.body?.map { it.barcode }).doesNotContain(uniqueBarcode)
+        assertThat(response.body?.map { it.clothingItem.barcode }).doesNotContain(uniqueBarcode)
     }
 
     // --- helpers ---
@@ -226,8 +235,7 @@ class ClothingItemLookupIT : IntegrationTest() {
         )
         val authCalls = AuthControllerCalls(testRestTemplate)
         val loginResponse = authCalls.login(username = username, password = password)
-        return authCalls.extractAuthCookie(loginResponse)
-            ?: error("Login failed for $username")
+        return authCalls.extractAuthCookie(loginResponse) ?: error("Login failed for $username")
     }
 
     private fun createLocation(

--- a/server/src/test/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ClothingItemLookupIT.kt
+++ b/server/src/test/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ClothingItemLookupIT.kt
@@ -1,0 +1,265 @@
+package io.github.simonhauck.openfirestationmanager.clothing.item
+
+import io.github.simonhauck.openfirestationmanager.IntegrationTest
+import io.github.simonhauck.openfirestationmanager.clothing.location.ClothingLocation
+import io.github.simonhauck.openfirestationmanager.clothing.location.ClothingLocationControllerCalls
+import io.github.simonhauck.openfirestationmanager.clothing.location.CreateClothingLocationRequest
+import io.github.simonhauck.openfirestationmanager.clothing.location.LocationType
+import io.github.simonhauck.openfirestationmanager.clothing.type.ClothingType
+import io.github.simonhauck.openfirestationmanager.clothing.type.CreateOrUpdateClothingTypeRequest
+import io.github.simonhauck.openfirestationmanager.clothing.type.ProtectiveClothingTypeControllerCalls
+import io.github.simonhauck.openfirestationmanager.security.auth.AuthControllerCalls
+import io.github.simonhauck.openfirestationmanager.usermanagement.AdminUserControllerCalls
+import io.github.simonhauck.openfirestationmanager.usermanagement.CreateUserRequest
+import io.github.simonhauck.openfirestationmanager.usermanagement.UserRole
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.resttestclient.TestRestTemplate
+import org.springframework.boot.resttestclient.exchange
+import org.springframework.data.jdbc.core.mapping.AggregateReference
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
+import org.springframework.http.ResponseEntity
+
+class ClothingItemLookupIT : IntegrationTest() {
+
+    @Autowired private lateinit var itemCalls: ClothingItemControllerCalls
+    @Autowired private lateinit var typeCalls: ProtectiveClothingTypeControllerCalls
+    @Autowired private lateinit var locationCalls: ClothingLocationControllerCalls
+    @Autowired private lateinit var adminUserCalls: AdminUserControllerCalls
+    @Autowired private lateinit var testRestTemplate: TestRestTemplate
+
+    // --- by-barcode ---
+
+    @Test
+    fun `by-barcode returns ResolvedClothingItem for a known barcode`() {
+        val type = createType()
+        val location = createLocation(LocationType.POOL)
+        val barcode = "BARCODE-${System.nanoTime()}"
+        itemCalls.createItem(
+            CreateOrUpdateClothingItemRequest(
+                typeId = type.id,
+                size = "L",
+                barcode = barcode,
+                locationId = AggregateReference.to(location.id),
+            ),
+            authCookie = validCookieHeader,
+        )
+
+        val response = getByBarcode(barcode, validCookieHeader)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.barcode).isEqualTo(barcode)
+        assertThat(response.body?.typeName).isEqualTo(type.name)
+        assertThat(response.body?.size).isEqualTo("L")
+        assertThat(response.body?.currentLocationId).isEqualTo(location.id)
+        assertThat(response.body?.currentLocationName).isEqualTo(location.name)
+        assertThat(response.body?.currentLocationType).isEqualTo(LocationType.POOL)
+    }
+
+    @Test
+    fun `by-barcode returns 404 for an unknown barcode`() {
+        val response = getByBarcodeExpectingError("UNKNOWN-${System.nanoTime()}", validCookieHeader)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+    }
+
+    @Test
+    fun `by-barcode returns 404 for item at Kleiderwart-only location when caller is not Kleiderwart`() {
+        val type = createType()
+        val restrictedLocation = createLocation(LocationType.PERSONAL, onlyVisibleForKleiderwart = true)
+        val barcode = "RESTRICTED-${System.nanoTime()}"
+        itemCalls.createItem(
+            CreateOrUpdateClothingItemRequest(
+                typeId = type.id,
+                size = "M",
+                barcode = barcode,
+                locationId = AggregateReference.to(restrictedLocation.id),
+            ),
+            authCookie = validCookieHeader,
+        )
+
+        val regularUserCookie = createRegularUserCookie()
+        val response = getByBarcodeExpectingError(barcode, regularUserCookie)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+    }
+
+    // --- search ---
+
+    @Test
+    fun `search matches items by type name (case-insensitive)`() {
+        val uniqueName = "SearchType-${System.nanoTime()}"
+        val type = createType(uniqueName)
+        itemCalls.createItem(
+            CreateOrUpdateClothingItemRequest(typeId = type.id, size = "XL"),
+            authCookie = validCookieHeader,
+        )
+
+        val response = search(uniqueName.lowercase(), validCookieHeader)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.map { it.typeName }).contains(uniqueName)
+    }
+
+    @Test
+    fun `search matches items by size (case-insensitive)`() {
+        val type = createType()
+        val uniqueSize = "size-${System.nanoTime()}"
+        itemCalls.createItem(
+            CreateOrUpdateClothingItemRequest(typeId = type.id, size = uniqueSize),
+            authCookie = validCookieHeader,
+        )
+
+        val response = search(uniqueSize.uppercase(), validCookieHeader)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.map { it.size }).contains(uniqueSize)
+    }
+
+    @Test
+    fun `search matches items by barcode (case-insensitive contains)`() {
+        val type = createType()
+        val uniqueBarcode = "BC-${System.nanoTime()}"
+        itemCalls.createItem(
+            CreateOrUpdateClothingItemRequest(typeId = type.id, size = "S", barcode = uniqueBarcode),
+            authCookie = validCookieHeader,
+        )
+
+        val response = search(uniqueBarcode.lowercase(), validCookieHeader)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.map { it.barcode }).contains(uniqueBarcode)
+    }
+
+    @Test
+    fun `search hard-caps results at 50 regardless of limit parameter`() {
+        val type = createType()
+        // Create 55 items to exceed the cap
+        repeat(55) {
+            itemCalls.createItem(
+                CreateOrUpdateClothingItemRequest(typeId = type.id, size = "CAP-TEST-${System.nanoTime()}"),
+                authCookie = validCookieHeader,
+            )
+        }
+
+        val response = search(type.name, validCookieHeader, limit = 100)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.size).isLessThanOrEqualTo(50)
+    }
+
+    @Test
+    fun `search filters out items at Kleiderwart-only locations for non-Kleiderwart callers`() {
+        val type = createType()
+        val restrictedLocation = createLocation(LocationType.PERSONAL, onlyVisibleForKleiderwart = true)
+        val uniqueBarcode = "FILTERED-${System.nanoTime()}"
+        itemCalls.createItem(
+            CreateOrUpdateClothingItemRequest(
+                typeId = type.id,
+                size = "M",
+                barcode = uniqueBarcode,
+                locationId = AggregateReference.to(restrictedLocation.id),
+            ),
+            authCookie = validCookieHeader,
+        )
+
+        val regularUserCookie = createRegularUserCookie()
+        val response = search(uniqueBarcode, regularUserCookie)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.map { it.barcode }).doesNotContain(uniqueBarcode)
+    }
+
+    // --- helpers ---
+
+    private fun getByBarcode(
+        barcode: String,
+        authCookie: String?,
+    ): ResponseEntity<ResolvedClothingItem> {
+        return testRestTemplate.exchange<ResolvedClothingItem>(
+            "/api/clothing/items/by-barcode/$barcode",
+            HttpMethod.GET,
+            HttpEntity<Unit>(headersWithCookie(authCookie)),
+        )
+    }
+
+    private fun getByBarcodeExpectingError(
+        barcode: String,
+        authCookie: String?,
+    ): ResponseEntity<ProblemDetail> {
+        return testRestTemplate.exchange<ProblemDetail>(
+            "/api/clothing/items/by-barcode/$barcode",
+            HttpMethod.GET,
+            HttpEntity<Unit>(headersWithCookie(authCookie)),
+        )
+    }
+
+    private fun search(
+        q: String,
+        authCookie: String?,
+        limit: Int = 50,
+    ): ResponseEntity<Array<ResolvedClothingItem>> {
+        return testRestTemplate.exchange<Array<ResolvedClothingItem>>(
+            "/api/clothing/items/search?q=$q&limit=$limit",
+            HttpMethod.GET,
+            HttpEntity<Unit>(headersWithCookie(authCookie)),
+        )
+    }
+
+    private fun createRegularUserCookie(): String {
+        val username = "user-${System.nanoTime()}"
+        val password = "pass1234"
+        adminUserCalls.createUser(
+            CreateUserRequest(
+                username = username,
+                password = password,
+                firstName = "Regular",
+                lastName = "User",
+                roles = listOf(UserRole.USER),
+            ),
+            authCookie = validCookieHeader,
+        )
+        val authCalls = AuthControllerCalls(testRestTemplate)
+        val loginResponse = authCalls.login(username = username, password = password)
+        return authCalls.extractAuthCookie(loginResponse)
+            ?: error("Login failed for $username")
+    }
+
+    private fun createLocation(
+        type: LocationType,
+        name: String = "Loc-${System.nanoTime()}",
+        onlyVisibleForKleiderwart: Boolean = false,
+    ): ClothingLocation {
+        return locationCalls
+            .createLocation(
+                CreateClothingLocationRequest(
+                    name = name,
+                    comment = "",
+                    onlyVisibleForKleiderwart = onlyVisibleForKleiderwart,
+                    type = type,
+                ),
+                authCookie = validCookieHeader,
+            )
+            .body!!
+    }
+
+    private fun createType(name: String = "Type-${System.nanoTime()}"): ClothingType {
+        return typeCalls
+            .createType(
+                CreateOrUpdateClothingTypeRequest(name = name),
+                authCookie = validCookieHeader,
+            )
+            .body!!
+    }
+
+    private fun headersWithCookie(authCookie: String?): HttpHeaders {
+        val headers = HttpHeaders()
+        if (authCookie != null) headers.add(HttpHeaders.COOKIE, authCookie)
+        return headers
+    }
+}


### PR DESCRIPTION
## Summary

Closes #59.

Two new read endpoints serving the checkout wizard's item picker, both returning a `ResolvedClothingItem` DTO that includes the item's current location name and type in a single response.

## Changes

### Server
- **`ResolvedClothingItem`** DTO — `id`, `barcode?`, `typeName`, `size`, `currentLocationId?`, `currentLocationName?`, `currentLocationType?`
- **`ClothingItemLookupService`** — encapsulates both lookup strategies and the `onlyVisibleForKleiderwart` visibility filter; hard-caps search at 50 results
- **`ClothingItemController`** — two new endpoints:
  - `GET /api/clothing/items/by-barcode/{barcode}` — strict equality; 404 on miss; 404 (not 403) when item is at a Kleiderwart-only location and caller is not Kleiderwart
  - `GET /api/clothing/items/search?q=&limit=` — case-insensitive contains across type name, size, and barcode; server enforces 50-result cap regardless of `limit`

### Client
- `schema.ts` regenerated from updated OpenAPI contract

## Tests

8 new integration tests in `ClothingItemLookupIT`, 58/58 passing:
- by-barcode hit (with full DTO field assertions)
- by-barcode miss → 404
- by-barcode Kleiderwart-only location, non-Kleiderwart caller → 404
- search type-name match (case-insensitive)
- search size match (case-insensitive)
- search barcode-contains match (case-insensitive)
- search hard-cap enforcement (50 max regardless of `limit=100`)
- search Kleiderwart-only filter for non-Kleiderwart callers