### PR TITLE
feat: show location comment in pickers (#110)

### DIFF
--- a/client/CONTEXT.md
+++ b/client/CONTEXT.md
@@ -12,6 +12,15 @@ The dashboard view at `/pool-clothing` summarising clothing on `POOL` and `WAESC
 
 User-facing label for `ClothingLocation`.
 
+Location pickers (combobox dropdowns) display a formatted label built from the location's fields:
+
+- Name only: `Spind 5`
+- Name + comment: `Spind 5 – Müller, Hans`
+- Name + type: `Spind 5 (Persönlicher Standort)`
+- Name + comment + type: `Spind 5 – Müller, Hans (Persönlicher Standort)`
+
+The `comment` field is used to hold supplementary context (e.g. the assigned person's name). Whether the type is shown depends on the picker context — checkout hides the type (all options are PERSONAL), relocation shows it (any type may appear).
+
 ### Klamotten / Kleidung
 
 Informal vs. formal labels for clothing items. Both appear in the UI; "Klamotten" tends to be used in headings/navigation, "Kleidung" in form labels.

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -22,6 +22,7 @@
         "@tanstack/react-query-devtools": "^5.91.3",
         "@tanstack/react-router": "latest",
         "@tanstack/react-router-devtools": "latest",
+        "@tanstack/router-plugin": "^1.132.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -38,7 +39,7 @@
         "@tailwindcss/typography": "^0.5.16",
         "@tanstack/devtools-vite": "latest",
         "@tanstack/eslint-config": "latest",
-        "@tanstack/router-plugin": "^1.167.35",
+        "@tanstack/router-plugin": "latest",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.0",
         "@types/node": "^24.0.0",
@@ -3296,9 +3297,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3314,9 +3312,6 @@
       "integrity": "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3334,9 +3329,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3352,9 +3344,6 @@
       "integrity": "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3372,9 +3361,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3390,9 +3376,6 @@
       "integrity": "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/client/src/clothing/checkout/components/CheckoutPage.tsx
+++ b/client/src/clothing/checkout/components/CheckoutPage.tsx
@@ -4,6 +4,10 @@ import { toast } from "sonner"
 import { useEffect, useRef, useState } from "react"
 
 import { getAllClothingLocationsQuery } from "#/clothing/service/clothingLocationsQueries"
+import {
+  formatClothingLocationLabel,
+  formatClothingLocationLabelOrDefault,
+} from "#/clothing/components/shared/clothingLocationLabel"
 import { getAllClothingItemsQuery } from "#/clothing/service/clothingItemsQueries"
 import { getAllClothingTypesQuery } from "#/clothing/service/clothingTypesQueries"
 import { useCheckoutWizard } from "#/clothing/checkout/useCheckoutWizard"
@@ -170,7 +174,7 @@ function StepTargetPicker({ onSelect }: StepTargetPickerProps) {
 
   const options: ComboboxOption[] = personalLocations.map((l) => ({
     value: String(l.id),
-    label: l.name,
+    label: formatClothingLocationLabel(l),
   }))
 
   const filteredOptions = options.filter((o) =>
@@ -239,7 +243,7 @@ function StepItemScanner({
       // Known non-POOL location — show discrepancy dialog
       setPendingConfirmation({
         item,
-        actualLocationName: location.name,
+        actualLocationName: formatClothingLocationLabel(location),
       })
       return
     }
@@ -265,7 +269,11 @@ function StepItemScanner({
             renderItemBadge={(item) => {
               const loc = item.location
               if (!loc || loc.type === "POOL") return null
-              return <Badge variant="outline">{loc.name}</Badge>
+              return (
+                <Badge variant="outline">
+                  {formatClothingLocationLabel(loc)}
+                </Badge>
+              )
             }}
           />
 
@@ -461,7 +469,9 @@ function StepWashLocationPicker({ onSelect }: StepWashLocationPickerProps) {
                 className="h-auto min-h-16 flex-col gap-1 p-4 text-wrap"
                 onClick={() => onSelect(loc.id)}
               >
-                <span className="text-base font-medium">{loc.name}</span>
+                <span className="text-base font-medium">
+                  {formatClothingLocationLabel(loc)}
+                </span>
               </TouchButton>
             ))}
           </div>
@@ -490,6 +500,9 @@ function StepReview({ state, onSubmitOk, onBack }: StepReviewProps) {
 
   const typeMap = new Map((allTypes ?? []).map((t) => [t.id, t]))
   const locationMap = new Map((allLocations ?? []).map((l) => [l.id, l]))
+  const targetLocationName = formatClothingLocationLabelOrDefault(
+    locationMap.get(state.targetLocationId!),
+  )
 
   // Resolved return items
   const returnItems: ResolvedClothingItem[] = [...state.returnItemIds].flatMap(
@@ -502,10 +515,11 @@ function StepReview({ state, onSubmitOk, onBack }: StepReviewProps) {
     },
   )
 
-  const washLocationName =
+  const location =
     state.returnLocationId !== null
-      ? (locationMap.get(state.returnLocationId)?.name ?? "–")
-      : "–"
+      ? locationMap.get(state.returnLocationId)
+      : undefined
+  const washLocationName = formatClothingLocationLabelOrDefault(location)
 
   async function handleSubmit() {
     const body = {
@@ -547,10 +561,7 @@ function StepReview({ state, onSubmitOk, onBack }: StepReviewProps) {
               ))}
             </div>
             <p className="text-muted-foreground text-sm">
-              Ziel:{" "}
-              <strong>
-                {locationMap.get(state.targetLocationId!)?.name ?? "–"}
-              </strong>
+              Ziel: <strong>{targetLocationName}</strong>
             </p>
           </RenderIf>
         </div>

--- a/client/src/clothing/components/shared/clothingLocationLabel.ts
+++ b/client/src/clothing/components/shared/clothingLocationLabel.ts
@@ -1,0 +1,41 @@
+import type { ClothingLocation } from "#/clothing/service/clothingLocationsQueries"
+
+type LocationType = ClothingLocation["type"]
+
+const LOCATION_TYPE_LABELS: Record<LocationType, string> = {
+  POOL: "Pool",
+  WAESCHE: "Wäsche",
+  PERSONAL: "Persönlicher Standort",
+  OTHER: "Sonstiges",
+}
+
+interface FormatClothingLocationLabelOptions {
+  showType?: boolean
+}
+
+export function formatClothingLocationLabel(
+  location: Pick<ClothingLocation, "name" | "comment" | "type">,
+  { showType = false }: FormatClothingLocationLabelOptions = {},
+): string {
+  let label = location.name
+
+  if (location.comment) {
+    label += ` – ${location.comment}`
+  }
+
+  if (showType) {
+    label += ` (${LOCATION_TYPE_LABELS[location.type]})`
+  }
+
+  return label
+}
+
+export function formatClothingLocationLabelOrDefault(
+  location: Pick<ClothingLocation, "name" | "comment" | "type"> | undefined,
+  options: FormatClothingLocationLabelOptions = {},
+  defaultValue = "–",
+): string {
+  return location
+    ? formatClothingLocationLabel(location, options)
+    : defaultValue
+}

--- a/client/src/clothing/relocation/components/RelocationPage.tsx
+++ b/client/src/clothing/relocation/components/RelocationPage.tsx
@@ -4,6 +4,10 @@ import { toast } from "sonner"
 import { useEffect, useState } from "react"
 
 import { getAllClothingLocationsQuery } from "#/clothing/service/clothingLocationsQueries"
+import {
+  formatClothingLocationLabel,
+  formatClothingLocationLabelOrDefault,
+} from "#/clothing/components/shared/clothingLocationLabel"
 import { useRelocationWizard } from "#/clothing/relocation/useRelocationWizard"
 import { relocationMutation } from "#/clothing/relocation/service/relocationQueries"
 import type { ResolvedClothingItem } from "#/clothing/checkout/service/checkoutQueries"
@@ -118,7 +122,7 @@ function StepTargetPicker({ onSelect }: StepTargetPickerProps) {
 
   const options: ComboboxOption[] = (allLocations ?? []).map((l) => ({
     value: String(l.id),
-    label: `${l.name} (${l.type})`,
+    label: formatClothingLocationLabel(l, { showType: true }),
   }))
 
   return (
@@ -205,10 +209,13 @@ function StepReview({ state, onSubmitOk, onBack }: StepReviewProps) {
   const relocate = useMutation(relocationMutation(queryClient))
 
   const locationMap = new Map((allLocations ?? []).map((l) => [l.id, l]))
-  const targetLocationName =
+  const location =
     state.targetLocationId !== null
-      ? (locationMap.get(state.targetLocationId)?.name ?? "–")
-      : "–"
+      ? locationMap.get(state.targetLocationId)
+      : undefined
+  const targetLocationName = formatClothingLocationLabelOrDefault(location, {
+    showType: true,
+  })
 
   async function handleSubmit() {
     try {
@@ -299,10 +306,12 @@ function StepSuccess({
   const [secondsLeft, setSecondsLeft] = useState(SUCCESS_REDIRECT_SECONDS)
 
   const locationMap = new Map((allLocations ?? []).map((l) => [l.id, l]))
-  const targetLocationName =
+  const targetLocationName = formatClothingLocationLabelOrDefault(
     state.targetLocationId !== null
-      ? (locationMap.get(state.targetLocationId)?.name ?? "–")
-      : "–"
+      ? locationMap.get(state.targetLocationId)
+      : undefined,
+    { showType: true },
+  )
 
   useEffect(() => {
     if (secondsLeft <= 0) {

--- a/server/CONTEXT.md
+++ b/server/CONTEXT.md
@@ -6,7 +6,7 @@ Domain language for the Spring Boot / Kotlin backend.
 
 ### ClothingLocation
 
-A physical place where clothing items can be stored. Every `ClothingItem` has at most one `locationId` (nullable). Locations are categorised by their `type`:
+A physical place where clothing items can be stored. Every `ClothingItem` has at most one `locationId` (nullable). Locations have a `name` (required) and an optional `comment` for additional context (e.g. the assigned person's name). Locations are categorised by their `type`:
 
 - **POOL** — shared stock that firefighters can take items *from*. Shown on the dashboard.
 - **WAESCHE** — laundry. Items can be returned *to* it but never taken *from* it. Shown on the dashboard.


### PR DESCRIPTION
Closes #110

## Summary

Add a `formatClothingLocationLabel` utility and apply it consistently across all user-facing location pickers and summaries so that the `comment` field (e.g. an assigned person's name) is displayed alongside the location name.

### Label format

| Condition | Result |
|---|---|
| Name only | `Spind 5` |
| Name + comment | `Spind 5 – Müller, Hans` |
| Name + type | `Spind 5 (Persönlicher Standort)` |
| Name + comment + type | `Spind 5 – Müller, Hans (Persönlicher Standort)` |

Type labels use human-readable German strings. Whether the type is shown depends on context — checkout hides it (all options are PERSONAL), relocation shows it (any type may appear).

### Changes

- **`clothingLocationLabel.ts`** — new shared utility with `formatClothingLocationLabel` and `formatClothingLocationLabelOrDefault` (for optional location arguments)
- **Checkout** — steps 1, 2, 4, 5 updated
- **Relocation** — steps 1, 3, 4 updated
- **CONTEXT.md** (client + server) — documented `comment` field and label format rules