### PR TITLE
fix: show German duplicate barcode error message on client

### DIFF
--- a/client/src/clothing/components/shared/ClothingItemForm.tsx
+++ b/client/src/clothing/components/shared/ClothingItemForm.tsx
@@ -66,7 +66,9 @@ export default function ClothingItemForm({
   const submitLabel = "Speichern"
   const pendingLabel = "Wird gespeichert..."
   const errorMessage = error
-    ? "Das Kleidungsstück konnte nicht gespeichert werden."
+    ? error instanceof Error
+      ? error.message
+      : "Das Kleidungsstück konnte nicht gespeichert werden."
     : null
 
   function handleSubmit(e: React.FormEvent) {

--- a/client/tests/pages/ClothingItemsPage.ts
+++ b/client/tests/pages/ClothingItemsPage.ts
@@ -82,6 +82,10 @@ export class ClothingItemsPage {
     return this.page.getByRole("row").filter({ hasText: barcode })
   }
 
+  formErrorAlert() {
+    return this.page.getByRole("alert")
+  }
+
   // --- Batch import ---
 
   async selectBatchType(typeName: string) {

--- a/client/tests/specs/clothing-items.spec.ts
+++ b/client/tests/specs/clothing-items.spec.ts
@@ -20,6 +20,31 @@ test.describe("Clothing Items", () => {
     await page.close()
   })
 
+  test("shows German error when creating an item with a duplicate barcode", async ({
+    page,
+  }) => {
+    const barcode = `BC-DUP-${randomUUID().slice(0, 8)}`
+    const itemsPage = new ClothingItemsPage(page)
+
+    await itemsPage.gotoNew()
+    await itemsPage.selectType(typeName)
+    await itemsPage.fillSize("L")
+    await itemsPage.fillBarcode(barcode)
+    await itemsPage.submitForm()
+    await expect(page).toHaveURL(/\/clothing-management\/items$/)
+
+    await itemsPage.gotoNew()
+    await itemsPage.selectType(typeName)
+    await itemsPage.fillSize("M")
+    await itemsPage.fillBarcode(barcode)
+    await itemsPage.submitForm()
+
+    await expect(page).toHaveURL(/\/clothing-management\/items\/new$/)
+    await expect(itemsPage.formErrorAlert()).toHaveText(
+      `Der Barcode '${barcode}' ist bereits in Verwendung.`,
+    )
+  })
+
   test("creates a new item and shows it in the list", async ({ page }) => {
     const barcode = `BC-${randomUUID().slice(0, 8)}`
     const itemsPage = new ClothingItemsPage(page)

--- a/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ClothingItemService.kt
+++ b/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ClothingItemService.kt
@@ -126,7 +126,7 @@ class ClothingItemService(
         if (barcode == null) return
         val existing = repository.findByBarcode(barcode)
         if (existing != null && existing.id != excludeId) {
-            throw ConflictException("Barcode '$barcode' is already in use")
+            throw ConflictException(barcodeAlreadyInUseMessage(barcode))
         }
     }
 
@@ -135,11 +135,19 @@ class ClothingItemService(
 
         val duplicates = barcodes.toSet().intersect(existingBarcodes)
         if (duplicates.isNotEmpty()) {
-            throw ConflictException(
-                "Die folgenden Barcodes sind bereits in Verwendung: ${duplicates.joinToString(", ")}"
-            )
+            throw ConflictException(barcodesAlreadyInUseMessage(duplicates))
         }
     }
+
+    private fun barcodeAlreadyInUseMessage(barcode: String): String =
+        "Der Barcode '$barcode' ist bereits in Verwendung."
+
+    private fun barcodesAlreadyInUseMessage(barcodes: Set<String>): String =
+        when (barcodes.size) {
+            1 -> barcodeAlreadyInUseMessage(barcodes.first())
+            else ->
+                "Die folgenden Barcodes sind bereits in Verwendung: ${barcodes.joinToString(", ")}"
+        }
 
     private fun checkNoDuplicateBarcodesProvided(barcodes: List<String>) {
         require(barcodes.size == barcodes.toSet().size) {


### PR DESCRIPTION
Returns a German error message from the server when a duplicate barcode is detected, displays the actual server error in the form instead of a generic message, and adds an E2E test covering the flow.