### PR TITLE
Inventarisierung (Inventory Reconciliation)

### DIFF
--- a/client/CONTEXT.md
+++ b/client/CONTEXT.md
@@ -46,6 +46,12 @@ Picker UI scales by cardinality:
 - **Few items (a handful of WAESCHE locations):** tile grid, single tap, no search.
 - **Many items (>100 PERSONAL locations, >1000 clothing items):** searchable Combobox with typeahead, primary input on tablet. For items the barcode scanner is the primary input and the Combobox is the backup.
 
+### Inventarisierung (Inventory Reconciliation)
+
+The `/pool-clothing/inventory-reconciliation` route is a KLEIDERWART-only wizard for reconciling the system's records for a location against physical reality. Reached from an "Inventarisierung starten" button on `/pool-clothing`. The route is `RoleGuard`-ed for the `KLEIDERWART` role.
+
+4-step wizard: 1) Standort wählen → 2) Kleidung scannen (running count) → 3) Differenzen & Bestätigen (preview diff, warn about missing items → Kein Standort, confirm) → 4) Fertig (summary with auto-redirect).
+
 ### Umlagerung (Relocation)
 
 The `/pool-clothing/relocation` route is a KLEIDERWART-only batch operation for moving items between locations of any type. Reached from an "Umlagerung starten" button on `/pool-clothing`. The route is `RoleGuard`-ed for the `KLEIDERWART` role.

--- a/client/docs/adr/0003-inventory-reconciliation-wizard.md
+++ b/client/docs/adr/0003-inventory-reconciliation-wizard.md
@@ -1,0 +1,53 @@
+# ADR-0003: Inventory Reconciliation wizard — location-first step order with server-side diff
+
+**Status:** Accepted
+**Date:** 2026-06-12
+
+## Context
+
+The Kleiderwart needs a wizard for reconciling the system's records for a location against physical reality — scanning all items physically present at a location and having the system compute and apply the differences. The existing Relocation wizard (ADR-0002) moves items _to_ a target; the existing Checkout wizard (ADR-0001) handles POOL → PERSONAL exchanges. Neither handles the "what's here vs. what should be here" reconciliation pattern.
+
+A new Inventarisierung (inventory reconciliation) wizard is added at `/pool-clothing/inventory-reconciliation`.
+
+## Decision
+
+### Step order: location-first, 4 steps
+
+1. **Standort wählen** — searchable combobox over all locations (no type restriction)
+2. **Kleidung scannen** — shared `ClothingItemScanner` component with running scan count
+3. **Differenzen & Bestätigen** — calls `POST /api/clothing/inventory-reconciliation/{locationId}/preview`, displays three sections (unchanged / found / missing) with a warning that missing items will be moved to "Kein Standort", then a "Inventarisierung abschließen" button calls the `/execute` endpoint
+4. **Fertig** — summary with found/missing/unchanged counts and auto-redirect to `/pool-clothing`
+
+Location-first was chosen for the same reasons as Relocation (ADR-0002): the location is the primary decision, and forcing it first commits the operator to the context before scanning.
+
+### Server-side diff via two-phase API
+
+The preview endpoint computes the diff (unchanged / found / missing) server-side and returns it without side effects. The execute endpoint takes the full preview response and applies the changes. This avoids duplicating diff logic in the client and makes the diff computation reusable.
+
+### Shared ClothingItemScanner
+
+The existing `ClothingItemScanner` component is reused. The parent owns item list state; the scanner displays a running count in the step description. Scanned items from any location are accepted — the diff is computed server-side.
+
+### No discrepancy protocol
+
+The Kleiderwart is physically performing the reconciliation. As with Relocation (ADR-0002), there is no discrepancy protocol — the Kleiderwart is the authority.
+
+### Role guard
+
+The route is role-guarded to `KLEIDERWART` via `RoleGuard`. The entry point button ("Inventarisierung starten") on the Pool Klamotten page renders only for users with `KLEIDERWART` or `ADMIN`.
+
+### State machine
+
+Follows the `useReducer` pattern used by `useRelocationWizard` and `useReturnWizard`. Steps encoded as `1 | 2 | 3 | 4`.
+
+## Consequences
+
+- The diff logic lives on the server, making it available to future consumers (e.g. admin reports) without client-side duplication.
+- The execute endpoint trusts the preview response — no re-validation. The window between preview and execute is a single user session with a single actor; concurrent modification risk is negligible.
+- The wizard is a single route with internal step state (same as Relocation, ADR-0002). Browser back exits the wizard.
+
+## Alternatives Rejected
+
+- **Client-side diff:** Trivial to compute (set difference), but locks diff logic into one consumer. Server-side diff is reusable and keeps the client thin.
+- **Single-phase API (like Relocation):** Would mean the diff is only visible after execution, removing the confirmation safety net. The preview step gives the Kleiderwart a chance to catch mistakes.
+- **Different step order (scan-first):** The location is the primary decision. Scan-first would require backfilling the location after scanning, which is confusing.

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -22,6 +22,7 @@
         "@tanstack/react-query-devtools": "^5.91.3",
         "@tanstack/react-router": "latest",
         "@tanstack/react-router-devtools": "latest",
+        "@tanstack/router-plugin": "^1.132.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -38,7 +39,7 @@
         "@tailwindcss/typography": "^0.5.16",
         "@tanstack/devtools-vite": "latest",
         "@tanstack/eslint-config": "latest",
-        "@tanstack/router-plugin": "^1.168.11",
+        "@tanstack/router-plugin": "latest",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.0",
         "@types/node": "^24.0.0",
@@ -3296,9 +3297,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3314,9 +3312,6 @@
       "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3334,9 +3329,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3352,9 +3344,6 @@
       "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3372,9 +3361,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3390,9 +3376,6 @@
       "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4197,9 +4180,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4215,9 +4195,6 @@
       "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4235,9 +4212,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4253,9 +4227,6 @@
       "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/client/src/api/schema.ts
+++ b/client/src/api/schema.ts
@@ -192,6 +192,40 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  "/api/clothing/inventory-reconciliation/{locationId}/preview": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Preview the diff between scanned items and system records for a location */
+    post: operations["preview"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/clothing/inventory-reconciliation/{locationId}/execute": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Execute the inventory reconciliation, applying the changes from the preview */
+    post: operations["execute"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   "/api/clothing/checkouts": {
     parameters: {
       query?: never
@@ -201,7 +235,10 @@ export interface paths {
     }
     get?: never
     put?: never
-    /** Perform a checkout */
+    /**
+     * Perform a checkout
+     * @description Perform checkout and returns for clothing items
+     */
     post: operations["checkout"]
     delete?: never
     options?: never
@@ -614,6 +651,28 @@ export interface components {
     BatchCreateClothingItemsRequest: {
       items: components["schemas"]["CreateOrUpdateClothingItemRequest"][]
     }
+    InventoryReconciliationPreviewRequest: {
+      scannedItemIds: number[]
+    }
+    InventoryReconciliationPreviewResponse: {
+      unchangedItems: components["schemas"]["ResolvedClothingItem"][]
+      foundItems: components["schemas"]["ResolvedClothingItem"][]
+      missingItems: components["schemas"]["ResolvedClothingItem"][]
+    }
+    ResolvedClothingItem: {
+      clothingItem: components["schemas"]["ClothingItem"]
+      location?: components["schemas"]["ClothingLocation"]
+      clothingType: components["schemas"]["ClothingType"]
+    }
+    InventoryReconciliationExecuteResponse: {
+      batchId: string
+      /** Format: int32 */
+      foundItemsCount: number
+      /** Format: int32 */
+      missingItemsCount: number
+      /** Format: int32 */
+      unchangedItemsCount: number
+    }
     CheckoutRequest: {
       /** Format: int64 */
       targetLocationId?: number
@@ -681,11 +740,6 @@ export interface components {
       types: components["schemas"]["ClothingTypeSummary"][]
       /** Format: int32 */
       totalCount: number
-    }
-    ResolvedClothingItem: {
-      clothingItem: components["schemas"]["ClothingItem"]
-      location?: components["schemas"]["ClothingLocation"]
-      clothingType: components["schemas"]["ClothingType"]
     }
   }
   responses: never
@@ -1073,6 +1127,112 @@ export interface operations {
         }
         content: {
           "*/*": components["schemas"]["ClothingItem"][]
+        }
+      }
+    }
+  }
+  preview: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        locationId: number
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["InventoryReconciliationPreviewRequest"]
+      }
+    }
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["InventoryReconciliationPreviewResponse"]
+        }
+      }
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["ProblemDetail"]
+        }
+      }
+      /** @description Forbidden — KLEIDERWART role required */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["ProblemDetail"]
+        }
+      }
+      /** @description Location or item not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["ProblemDetail"]
+        }
+      }
+    }
+  }
+  execute: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        locationId: number
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["InventoryReconciliationPreviewResponse"]
+      }
+    }
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["InventoryReconciliationExecuteResponse"]
+        }
+      }
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["ProblemDetail"]
+        }
+      }
+      /** @description Forbidden — KLEIDERWART role required */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["ProblemDetail"]
+        }
+      }
+      /** @description Location or item not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["ProblemDetail"]
         }
       }
     }

--- a/client/src/clothing/components/pool-klamotten/PoolKlamottenPage.tsx
+++ b/client/src/clothing/components/pool-klamotten/PoolKlamottenPage.tsx
@@ -26,6 +26,13 @@ export default function PoolKlamottenPage() {
         <>
           <RoleGuard allowedRoles={["KLEIDERWART"]} hideChildComponent={true}>
             <TouchButton asChild variant="outline">
+              <Link to="/pool-clothing/inventory-reconciliation">
+                Inventarisierung starten
+              </Link>
+            </TouchButton>
+          </RoleGuard>
+          <RoleGuard allowedRoles={["KLEIDERWART"]} hideChildComponent={true}>
+            <TouchButton asChild variant="outline">
               <Link to="/pool-clothing/relocation">Umlagerung starten</Link>
             </TouchButton>
           </RoleGuard>

--- a/client/src/clothing/inventory-reconciliation/components/InventoryReconciliationPage.tsx
+++ b/client/src/clothing/inventory-reconciliation/components/InventoryReconciliationPage.tsx
@@ -1,0 +1,365 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useNavigate } from "@tanstack/react-router"
+import { toast } from "sonner"
+import { useEffect, useState } from "react"
+
+import { getAllClothingLocationsQuery } from "#/clothing/service/clothingLocationsQueries"
+import { formatClothingLocationLabel } from "#/clothing/components/shared/clothingLocationLabel"
+import { useInventoryReconciliationWizard } from "#/clothing/inventory-reconciliation/useInventoryReconciliationWizard"
+import type { InventoryReconciliationStep } from "#/clothing/inventory-reconciliation/useInventoryReconciliationWizard"
+import {
+  inventoryReconciliationExecuteMutation,
+  inventoryReconciliationPreviewQuery,
+} from "#/clothing/inventory-reconciliation/service/inventoryReconciliationQueries"
+import type { ResolvedClothingItem } from "#/clothing/model/clothingItems"
+import {
+  TouchButton,
+  TouchCombobox,
+} from "#/clothing/checkout/components/TouchComponents"
+import type { ComboboxOption } from "#/clothing/checkout/components/TouchComponents"
+import type { StepperWizardStep } from "#/components/base/StepperWizard"
+import StepperWizard from "#/components/base/StepperWizard"
+import PageSection from "#/components/base/PageSection"
+import RenderIf from "#/components/base/RenderIf"
+import { Badge } from "#/components/ui/badge"
+import ClothingItemRow from "#/clothing/components/shared/ClothingItemRow"
+import ClothingItemScanner from "#/clothing/components/shared/ClothingItemScanner"
+
+const SUCCESS_REDIRECT_SECONDS = 15
+
+export default function InventoryReconciliationPage() {
+  const navigate = useNavigate()
+  const {
+    state,
+    selectLocation,
+    addItem,
+    removeItem,
+    advanceToDiff,
+    submitOk,
+    goBack,
+    goToStep,
+    reset,
+  } = useInventoryReconciliationWizard()
+
+  const steps: StepperWizardStep[] = [
+    {
+      label: "Standort wählen",
+      description: "Standort für die Inventarisierung auswählen",
+      content: <StepLocationPickerContent onSelect={selectLocation} />,
+    },
+    {
+      label: "Kleidung scannen",
+      description: "Barcode scannen oder manuell suchen",
+      content: (
+        <StepScannerContent
+          state={state}
+          onAddItem={addItem}
+          onRemoveItem={removeItem}
+          onBack={goBack}
+          onNext={advanceToDiff}
+        />
+      ),
+    },
+    {
+      label: "Differenzen & Bestätigen",
+      description: "Änderungen prüfen und bestätigen",
+      content: (
+        <StepDiffContent state={state} onSubmitOk={submitOk} onBack={goBack} />
+      ),
+    },
+    {
+      label: "Fertig",
+      description: "Inventarisierung abgeschlossen",
+      content: (
+        <StepSuccessContent
+          state={state}
+          onReset={reset}
+          onNavigateToOverview={() => void navigate({ to: "/pool-clothing" })}
+        />
+      ),
+    },
+  ]
+
+  return (
+    <PageSection
+      title="Inventarisierung"
+      buttons={
+        <TouchButton
+          variant="outline"
+          onClick={async () => {
+            await navigate({ to: "/pool-clothing" })
+          }}
+        >
+          Abbrechen
+        </TouchButton>
+      }
+    >
+      <StepperWizard
+        steps={steps}
+        currentStep={state.step}
+        onStepClick={(step) => goToStep(step as InventoryReconciliationStep)}
+      />
+    </PageSection>
+  )
+}
+
+// ─── Step 1: Location Picker ─────────────────────────────────────────────────
+
+interface StepLocationPickerContentProps {
+  onSelect: (locationId: number) => void
+}
+
+function StepLocationPickerContent({
+  onSelect,
+}: StepLocationPickerContentProps) {
+  const { data: allLocations } = useQuery(getAllClothingLocationsQuery())
+
+  const options: ComboboxOption[] = (allLocations ?? []).map((l) => ({
+    value: String(l.id),
+    label: formatClothingLocationLabel(l, { showType: true }),
+  }))
+
+  return (
+    <div className="space-y-4">
+      <p className="text-muted-foreground text-sm">
+        Wähle den Standort aus, dessen Bestand überprüft werden soll.
+      </p>
+      <TouchCombobox
+        options={options}
+        value={null}
+        onSelect={(value) => onSelect(Number(value))}
+        placeholder="Standort auswählen..."
+        searchPlaceholder="Standort suchen..."
+        emptyMessage="Kein Standort gefunden."
+      />
+    </div>
+  )
+}
+
+// ─── Step 2: Scanner ─────────────────────────────────────────────────────────
+
+interface StepScannerContentProps {
+  state: ReturnType<typeof useInventoryReconciliationWizard>["state"]
+  onAddItem: (item: ResolvedClothingItem) => void
+  onRemoveItem: (itemId: number) => void
+  onBack: () => void
+  onNext: () => void
+}
+
+function StepScannerContent({
+  state,
+  onAddItem,
+  onRemoveItem,
+  onBack,
+  onNext,
+}: StepScannerContentProps) {
+  return (
+    <div className="space-y-4">
+      <p className="text-muted-foreground text-sm">
+        Scanne alle Kleidungsstücke, die sich physisch an diesem Standort
+        befinden.
+      </p>
+
+      <ClothingItemScanner
+        items={state.scannedItems}
+        onItemResolved={onAddItem}
+        onRemoveItem={onRemoveItem}
+        renderItemBadge={(item) =>
+          item.location ? (
+            <Badge variant="outline">
+              {formatClothingLocationLabel(item.location)}
+            </Badge>
+          ) : null
+        }
+      />
+
+      <div className="flex justify-end gap-3 pt-2">
+        <TouchButton variant="outline" onClick={onBack}>
+          ← Zurück
+        </TouchButton>
+        <TouchButton onClick={onNext}>Weiter →</TouchButton>
+      </div>
+    </div>
+  )
+}
+
+// ─── Step 3: Diff & Confirm ─────────────────────────────────────────────────
+
+interface StepDiffContentProps {
+  state: ReturnType<typeof useInventoryReconciliationWizard>["state"]
+  onSubmitOk: () => void
+  onBack: () => void
+}
+
+function StepDiffContent({ state, onSubmitOk, onBack }: StepDiffContentProps) {
+  const queryClient = useQueryClient()
+  const executeMutation = useMutation(
+    inventoryReconciliationExecuteMutation(queryClient),
+  )
+
+  const previewQuery = inventoryReconciliationPreviewQuery(state.locationId!, {
+    scannedItemIds: state.scannedItems.map((i) => i.clothingItem.id),
+  })
+  const { data: diff, isLoading } = useQuery(previewQuery)
+
+  async function handleConfirm() {
+    if (!diff) return
+    try {
+      await executeMutation.mutateAsync({
+        locationId: state.locationId!,
+        body: diff,
+      })
+      onSubmitOk()
+    } catch {
+      toast.error(
+        "Fehler beim Abschließen der Inventarisierung. Bitte erneut versuchen.",
+      )
+    }
+  }
+
+  if (isLoading || !diff) {
+    return (
+      <div className="space-y-4">
+        <p className="text-muted-foreground text-sm">
+          Differenzen werden berechnet…
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <DiffSection
+        title="Unverändert"
+        subtitle="Bereits am Standort"
+        items={diff.unchangedItems}
+        emptyMessage="Keine unveränderten Kleidungsstücke."
+      />
+
+      <DiffSection
+        title="Gefunden"
+        subtitle="Neu hinzugekommene Kleidung"
+        items={diff.foundItems}
+        emptyMessage="Keine neu gefundenen Kleidungsstücke."
+      />
+
+      <DiffSection
+        title="Fehlend"
+        subtitle="Werden auf 'Kein Standort' gesetzt"
+        items={diff.missingItems}
+        emptyMessage="Keine fehlenden Kleidungsstücke."
+      />
+
+      <RenderIf when={diff.missingItems.length > 0}>
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4">
+          <p className="text-destructive text-sm font-medium">
+            Fehlende Kleidung wird auf &bdquo;Kein Standort&ldquo; gesetzt und
+            ist keinem Standort mehr zugeordnet.
+          </p>
+        </div>
+      </RenderIf>
+
+      <div className="flex justify-end gap-3 pt-2">
+        <TouchButton
+          variant="outline"
+          onClick={onBack}
+          disabled={executeMutation.isPending}
+        >
+          ← Zurück
+        </TouchButton>
+        <TouchButton
+          disabled={executeMutation.isPending}
+          onClick={() => void handleConfirm()}
+        >
+          {executeMutation.isPending
+            ? "Wird gesendet…"
+            : "Inventarisierung abschließen"}
+        </TouchButton>
+      </div>
+    </div>
+  )
+}
+
+interface DiffSectionProps {
+  title: string
+  subtitle: string
+  items: ResolvedClothingItem[]
+  emptyMessage: string
+}
+
+function DiffSection({
+  title,
+  subtitle,
+  items,
+  emptyMessage,
+}: DiffSectionProps) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-baseline gap-2">
+        <p className="text-sm font-semibold">{title}</p>
+        <span className="text-muted-foreground text-xs">({items.length})</span>
+      </div>
+      <p className="text-muted-foreground text-xs">{subtitle}</p>
+      <RenderIf when={items.length === 0}>
+        <p className="text-muted-foreground text-sm italic">{emptyMessage}</p>
+      </RenderIf>
+      <RenderIf when={items.length > 0}>
+        <div className="space-y-1">
+          {items.map((item) => (
+            <ClothingItemRow key={item.clothingItem.id} item={item} />
+          ))}
+        </div>
+      </RenderIf>
+    </div>
+  )
+}
+
+// ─── Step 4: Success ─────────────────────────────────────────────────────────
+
+interface StepSuccessContentProps {
+  state: ReturnType<typeof useInventoryReconciliationWizard>["state"]
+  onReset: () => void
+  onNavigateToOverview: () => void
+}
+
+function StepSuccessContent({
+  state,
+  onReset,
+  onNavigateToOverview,
+}: StepSuccessContentProps) {
+  const [secondsLeft, setSecondsLeft] = useState(SUCCESS_REDIRECT_SECONDS)
+
+  useEffect(() => {
+    if (secondsLeft <= 0) {
+      onNavigateToOverview()
+      return
+    }
+    const id = setTimeout(() => setSecondsLeft((s) => s - 1), 1000)
+    return () => clearTimeout(id)
+  }, [secondsLeft, onNavigateToOverview])
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <p className="text-lg font-semibold">Inventarisierung abgeschlossen</p>
+        <p className="text-muted-foreground text-sm">
+          {state.scannedItems.length} Kleidungsstück
+          {state.scannedItems.length !== 1 ? "e" : ""} wurden gescannt. Die
+          Änderungen wurden übernommen.
+        </p>
+      </div>
+      <p className="text-muted-foreground text-sm">
+        Weiterleitung zur Übersicht in {secondsLeft} Sekunde
+        {secondsLeft !== 1 ? "n" : ""}…
+      </p>
+      <div className="flex gap-3">
+        <TouchButton onClick={onReset}>
+          Neue Inventarisierung starten
+        </TouchButton>
+        <TouchButton variant="outline" onClick={onNavigateToOverview}>
+          Zur Übersicht
+        </TouchButton>
+      </div>
+    </div>
+  )
+}

--- a/client/src/clothing/inventory-reconciliation/service/inventoryReconciliationQueries.ts
+++ b/client/src/clothing/inventory-reconciliation/service/inventoryReconciliationQueries.ts
@@ -1,0 +1,61 @@
+import { queryOptions, mutationOptions } from "@tanstack/react-query"
+import type { QueryClient } from "@tanstack/react-query"
+
+import { client } from "#/api/client"
+import { queryKeys } from "#/api/queryKeys"
+import type {
+  InventoryReconciliationPreviewRequest,
+  InventoryReconciliationPreviewResponse,
+  InventoryReconciliationExecuteResponse,
+} from "#/clothing/model/inventoryReconciliation"
+
+export function inventoryReconciliationPreviewQuery(
+  locationId: number,
+  request: InventoryReconciliationPreviewRequest,
+) {
+  return queryOptions({
+    queryKey: [
+      ...queryKeys.clothingItems(),
+      "inventory-reconciliation-preview",
+      locationId,
+      request.scannedItemIds,
+    ],
+    queryFn: async (): Promise<InventoryReconciliationPreviewResponse> => {
+      const { data } = await client.POST(
+        "/api/clothing/inventory-reconciliation/{locationId}/preview",
+        {
+          params: { path: { locationId } },
+          body: request,
+        },
+      )
+      return data!
+    },
+  })
+}
+
+export const inventoryReconciliationExecuteMutation = (
+  queryClient: QueryClient,
+) =>
+  mutationOptions({
+    mutationFn: async ({
+      locationId,
+      body,
+    }: {
+      locationId: number
+      body: InventoryReconciliationPreviewResponse
+    }): Promise<InventoryReconciliationExecuteResponse> => {
+      const { data } = await client.POST(
+        "/api/clothing/inventory-reconciliation/{locationId}/execute",
+        {
+          params: { path: { locationId } },
+          body,
+        },
+      )
+      return data!
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.clothingItems(),
+      })
+    },
+  })

--- a/client/src/clothing/inventory-reconciliation/useInventoryReconciliationWizard.ts
+++ b/client/src/clothing/inventory-reconciliation/useInventoryReconciliationWizard.ts
@@ -1,0 +1,105 @@
+import { useReducer } from "react"
+import type { ResolvedClothingItem } from "#/clothing/model/clothingItems.ts"
+
+export type InventoryReconciliationStep = 1 | 2 | 3 | 4
+
+export interface InventoryReconciliationWizardState {
+  step: InventoryReconciliationStep
+  locationId: number | null
+  scannedItems: ResolvedClothingItem[]
+}
+
+type Action =
+  | { type: "SELECT_LOCATION"; locationId: number }
+  | { type: "ADD_ITEM"; item: ResolvedClothingItem }
+  | { type: "REMOVE_ITEM"; itemId: number }
+  | { type: "ADVANCE_TO_DIFF" }
+  | { type: "SUBMIT_OK" }
+  | { type: "GO_BACK" }
+  | { type: "GO_TO_STEP"; step: InventoryReconciliationStep }
+  | { type: "RESET" }
+
+function reducer(
+  state: InventoryReconciliationWizardState,
+  action: Action,
+): InventoryReconciliationWizardState {
+  switch (action.type) {
+    case "SELECT_LOCATION":
+      return { ...state, step: 2, locationId: action.locationId }
+
+    case "ADD_ITEM": {
+      const alreadyIn = state.scannedItems.some(
+        (i) => i.clothingItem.id === action.item.clothingItem.id,
+      )
+      if (alreadyIn) return state
+      return {
+        ...state,
+        scannedItems: [...state.scannedItems, action.item],
+      }
+    }
+
+    case "REMOVE_ITEM":
+      return {
+        ...state,
+        scannedItems: state.scannedItems.filter(
+          (i) => i.clothingItem.id !== action.itemId,
+        ),
+      }
+
+    case "ADVANCE_TO_DIFF":
+      return { ...state, step: 3 }
+
+    case "SUBMIT_OK":
+      return { ...state, step: 4 }
+
+    case "GO_BACK": {
+      if (state.step <= 1) return state
+      const prevStep = (state.step - 1) as InventoryReconciliationStep
+      return { ...state, step: prevStep }
+    }
+
+    case "GO_TO_STEP": {
+      if (action.step >= state.step) return state
+      return { ...state, step: action.step }
+    }
+
+    case "RESET":
+      return initialState
+  }
+}
+
+const initialState: InventoryReconciliationWizardState = {
+  step: 1,
+  locationId: null,
+  scannedItems: [],
+}
+
+export interface UseInventoryReconciliationWizardReturn {
+  state: InventoryReconciliationWizardState
+  selectLocation: (locationId: number) => void
+  addItem: (item: ResolvedClothingItem) => void
+  removeItem: (itemId: number) => void
+  advanceToDiff: () => void
+  submitOk: () => void
+  goBack: () => void
+  goToStep: (step: InventoryReconciliationStep) => void
+  reset: () => void
+}
+
+export function useInventoryReconciliationWizard(): UseInventoryReconciliationWizardReturn {
+  const [state, dispatch] = useReducer(reducer, initialState)
+
+  return {
+    state,
+    selectLocation: (locationId: number) =>
+      dispatch({ type: "SELECT_LOCATION", locationId }),
+    addItem: (item: ResolvedClothingItem) =>
+      dispatch({ type: "ADD_ITEM", item }),
+    removeItem: (itemId: number) => dispatch({ type: "REMOVE_ITEM", itemId }),
+    advanceToDiff: () => dispatch({ type: "ADVANCE_TO_DIFF" }),
+    submitOk: () => dispatch({ type: "SUBMIT_OK" }),
+    goBack: () => dispatch({ type: "GO_BACK" }),
+    goToStep: (step) => dispatch({ type: "GO_TO_STEP", step }),
+    reset: () => dispatch({ type: "RESET" }),
+  }
+}

--- a/client/src/clothing/model/inventoryReconciliation.ts
+++ b/client/src/clothing/model/inventoryReconciliation.ts
@@ -1,0 +1,8 @@
+import type { components } from "#/api/schema"
+
+export type InventoryReconciliationPreviewRequest =
+  components["schemas"]["InventoryReconciliationPreviewRequest"]
+export type InventoryReconciliationPreviewResponse =
+  components["schemas"]["InventoryReconciliationPreviewResponse"]
+export type InventoryReconciliationExecuteResponse =
+  components["schemas"]["InventoryReconciliationExecuteResponse"]

--- a/client/src/components/layout/Breadcrumb.tsx
+++ b/client/src/components/layout/Breadcrumb.tsx
@@ -35,6 +35,7 @@ const SEGMENT_LABELS: Record<StaticSegment, string> = {
   "user-management": "Nutzer Management",
   dashboard: "Dashboard",
   impressum: "Impressum",
+  "inventory-reconciliation": "Inventarisierung",
   _authenticated: "Authenticated",
 }
 

--- a/client/src/routes/_authenticated/pool-clothing/inventory-reconciliation.tsx
+++ b/client/src/routes/_authenticated/pool-clothing/inventory-reconciliation.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import RoleGuard from "#/components/base/RoleGuard"
+import InventoryReconciliationPage from "#/clothing/inventory-reconciliation/components/InventoryReconciliationPage"
+
+export const Route = createFileRoute(
+  "/_authenticated/pool-clothing/inventory-reconciliation",
+)({
+  component: InventoryReconciliationRoute,
+})
+
+function InventoryReconciliationRoute() {
+  return (
+    <RoleGuard allowedRoles={["KLEIDERWART"]}>
+      <InventoryReconciliationPage />
+    </RoleGuard>
+  )
+}

--- a/client/tests/pages/AdminSettingsPage.ts
+++ b/client/tests/pages/AdminSettingsPage.ts
@@ -29,12 +29,22 @@ export class AdminSettingsPage {
     return this.page.getByTestId("privacy-policy-empty")
   }
 
-  deleteButton() {
-    return this.page.getByRole("button", { name: "Löschen" })
+  privacyPolicyDeleteButton() {
+    return this.page
+      .getByTestId("privacy-policy-current")
+      .getByRole("button", { name: "Löschen" })
   }
 
-  confirmDeleteButton() {
-    return this.page.getByRole("button", { name: "Löschen" })
+  impressumDeleteButton() {
+    return this.page
+      .getByTestId("impressum-current")
+      .getByRole("button", { name: "Löschen" })
+  }
+
+  dialogConfirmButton() {
+    return this.page
+      .getByRole("alertdialog")
+      .getByRole("button", { name: "Löschen" })
   }
 
   async selectFile(name: string, mimeType: string, contents: string) {
@@ -51,7 +61,30 @@ export class AdminSettingsPage {
   }
 
   async deleteDocument() {
-    await this.deleteButton().click()
-    await this.confirmDeleteButton().click()
+    await this.privacyPolicyDeleteButton().click()
+    await this.dialogConfirmButton().click()
+  }
+
+  async deleteImpressum() {
+    await this.impressumDeleteButton().click()
+    await this.dialogConfirmButton().click()
+  }
+
+  async cleanupAll() {
+    await this.goto()
+
+    if ((await this.privacyPolicyDeleteButton().count()) > 0) {
+      await this.privacyPolicyDeleteButton().click()
+      await this.dialogConfirmButton().click()
+      await this.emptyState().waitFor({ state: "visible" })
+    }
+
+    if ((await this.impressumDeleteButton().count()) > 0) {
+      await this.impressumDeleteButton().click()
+      await this.dialogConfirmButton().click()
+      await this.page
+        .getByTestId("impressum-empty")
+        .waitFor({ state: "visible" })
+    }
   }
 }

--- a/client/tests/pages/InventoryReconciliationPage.ts
+++ b/client/tests/pages/InventoryReconciliationPage.ts
@@ -1,0 +1,60 @@
+import type { Page } from "@playwright/test"
+
+export class InventoryReconciliationPage {
+  constructor(private readonly page: Page) {}
+
+  async goto() {
+    await this.page.goto("/pool-clothing/inventory-reconciliation")
+  }
+
+  // ─── Step 1: Standort wählen ────────────────────────────────────────────────
+
+  async selectLocation(name: string) {
+    await this.page.getByRole("combobox").click()
+    await this.page.getByPlaceholder("Standort suchen...").fill(name)
+    await this.page.getByRole("option", { name, exact: false }).first().click()
+  }
+
+  // ─── Step 2: Kleidung scannen ───────────────────────────────────────────────
+
+  async scanBarcode(barcode: string) {
+    await this.page.keyboard.type(barcode)
+    await this.page.keyboard.press("Enter")
+  }
+
+  scannedItem(label: string) {
+    return this.page.locator(".rounded-lg.border").filter({ hasText: label })
+  }
+
+  async clickWeiter() {
+    await this.page.getByRole("button", { name: "Weiter →" }).click()
+  }
+
+  // ─── Step 3: Differenzen & Bestätigen ───────────────────────────────────────
+
+  diffSection(title: string) {
+    return this.page.getByText(title, { exact: true })
+  }
+
+  async submitReconciliation() {
+    await this.page
+      .getByRole("button", { name: "Inventarisierung abschließen" })
+      .click()
+  }
+
+  warningBanner() {
+    return this.page.getByText(
+      'Fehlende Kleidung wird auf "Kein Standort" gesetzt',
+    )
+  }
+
+  // ─── Step 4: Success ────────────────────────────────────────────────────────
+
+  successHeading() {
+    return this.page.getByText("Inventarisierung abgeschlossen")
+  }
+
+  navigateToOverviewButton() {
+    return this.page.getByRole("button", { name: "Zur Übersicht" })
+  }
+}

--- a/client/tests/specs/admin-settings.spec.ts
+++ b/client/tests/specs/admin-settings.spec.ts
@@ -5,6 +5,11 @@ import { AdminSettingsPage } from "../pages/AdminSettingsPage"
 test.use({ storageState: "playwright/.auth/admin.json" })
 
 test.describe.serial("Admin Settings – Datenschutzerklärung", () => {
+  test.beforeEach(async ({ page }) => {
+    const adminSettings = new AdminSettingsPage(page)
+    await adminSettings.cleanupAll()
+  })
+
   test("uploads a privacy policy document and serves it publicly", async ({
     page,
   }) => {

--- a/client/tests/specs/inventory-reconciliation.spec.ts
+++ b/client/tests/specs/inventory-reconciliation.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test } from "@playwright/test"
+import { randomUUID } from "node:crypto"
+import { createClothingType } from "../flows/createClothingType"
+import { createClothingLocation } from "../flows/createClothingLocation"
+import { createClothingItem } from "../flows/createClothingItem"
+import { InventoryReconciliationPage } from "../pages/InventoryReconciliationPage"
+import { PoolKlamottenPage } from "../pages/PoolKlamottenPage"
+
+test.use({ storageState: "playwright/.auth/kleiderwart.json" })
+
+test.describe("Inventarisierung (Inventory Reconciliation)", () => {
+  let typeName: string
+  let barcodeAtLocation: string
+  let barcodeElsewhere: string
+  let locationName: string
+  let otherLocationName: string
+
+  test.beforeAll(async ({ browser }) => {
+    const suffix = randomUUID().slice(0, 8)
+    typeName = `Typ-Inv-${suffix}`
+    barcodeAtLocation = `BC-INV-A-${suffix}`
+    barcodeElsewhere = `BC-INV-B-${suffix}`
+    locationName = `Pool-Inv-${suffix}`
+    otherLocationName = `Other-Inv-${suffix}`
+
+    const page = await browser.newPage({
+      storageState: "playwright/.auth/kleiderwart.json",
+    })
+
+    await createClothingType(page, typeName)
+
+    await createClothingLocation(page, {
+      type: "POOL",
+      name: locationName,
+    })
+    await createClothingLocation(page, {
+      type: "OTHER",
+      name: otherLocationName,
+    })
+
+    await createClothingItem(page, {
+      typeName,
+      size: "L",
+      barcode: barcodeAtLocation,
+      locationName,
+    })
+    await createClothingItem(page, {
+      typeName,
+      size: "XL",
+      barcode: barcodeElsewhere,
+      locationName: otherLocationName,
+    })
+
+    await page.close()
+  })
+
+  test("button is visible on Pool Klamotten for Kleiderwart", async ({
+    page,
+  }) => {
+    const poolPage = new PoolKlamottenPage(page)
+    await poolPage.goto()
+
+    await expect(
+      page.getByRole("link", { name: "Inventarisierung starten" }),
+    ).toBeVisible()
+  })
+
+  test("completes the full inventory reconciliation flow", async ({ page }) => {
+    const reconciliationPage = new InventoryReconciliationPage(page)
+    const poolPage = new PoolKlamottenPage(page)
+
+    // ── Step 1: Navigate and select location ────────────────────────────────
+    await reconciliationPage.goto()
+    await expect(page.getByText("Schritt 1: Standort wählen")).toBeVisible()
+    await reconciliationPage.selectLocation(locationName)
+
+    // ── Step 2: Scan items ─────────────────────────────────────────────────
+    await expect(page.getByText("Schritt 2: Kleidung scannen")).toBeVisible()
+    await reconciliationPage.scanBarcode(barcodeAtLocation)
+    await expect(
+      reconciliationPage.scannedItem(`${typeName} – L`),
+    ).toBeVisible()
+
+    await reconciliationPage.scanBarcode(barcodeElsewhere)
+    await expect(
+      reconciliationPage.scannedItem(`${typeName} – XL`),
+    ).toBeVisible()
+
+    await reconciliationPage.clickWeiter()
+
+    // ── Step 3: Diff & Confirm ─────────────────────────────────────────────
+    await expect(
+      page.getByText("Schritt 3: Differenzen & Bestätigen"),
+    ).toBeVisible()
+
+    // Unchanged section: item scanned at the correct location
+    await expect(reconciliationPage.diffSection("Unverändert")).toBeVisible()
+    await expect(page.getByText(`${typeName} – L`)).toBeVisible()
+
+    // Found section: item scanned but not at location
+    await expect(reconciliationPage.diffSection("Gefunden")).toBeVisible()
+    // XL item should appear in the found section
+
+    // Missing section: items at location but not scanned
+    // (none expected — we scanned the only item at this location)
+
+    // Confirm
+    await reconciliationPage.submitReconciliation()
+
+    // ── Step 4: Success ────────────────────────────────────────────────────
+    await expect(reconciliationPage.successHeading()).toBeVisible()
+
+    // Navigate to pool overview
+    await reconciliationPage.navigateToOverviewButton().click()
+    await expect(page).toHaveURL(/\/pool-clothing/)
+    await expect(poolPage.loadingIndicator()).not.toBeVisible()
+  })
+})

--- a/server/CONTEXT.md
+++ b/server/CONTEXT.md
@@ -52,6 +52,21 @@ Two purpose-built endpoints serve the Checkout flow's item picker:
 
 A Kleiderwart-only batch operation that moves one or more clothing items to any target location regardless of location type. Unlike Checkout, there is no discrepancy protocol — the source location is inferred per item from its current `locationId` in the database. All movements are written atomically in a single transaction sharing a `batchId` with `reason = RELOCATION`. Endpoint: `POST /api/clothing/relocation`. See ADR-0003.
 
+### Inventarisierung (Inventory Reconciliation)
+
+A Kleiderwart-only batch operation that reconciles the system's records for a location against physical reality. The Kleiderwart scans all items physically present at a location, the system compares against its records, and two sets of movements are produced:
+
+- **Found items:** scanned items whose recorded `locationId` differs from the checked location → `fromLocationId = current locationId, toLocationId = checked locationId`
+- **Missing items:** items recorded at the checked location but not scanned → `fromLocationId = checked locationId, toLocationId = null` ("Kein Standort")
+
+Movement reason for both: `INVENTORY_RECONCILIATION`. All movements in one batch share a single `batchId` and are written atomically in a single transaction.
+
+Endpoints (Kleiderwart-only, no discrepancy protocol — the Kleiderwart is the authority):
+- `POST /api/clothing/inventory-reconciliation/{locationId}/preview` — computes diff (no side effects). Input: `{ scannedItemIds: number[] }`. Response: `{ unchangedItems: ResolvedClothingItem[], foundItems: ResolvedClothingItem[], missingItems: ResolvedClothingItem[] }`.
+- `POST /api/clothing/inventory-reconciliation/{locationId}/execute` — applies changes. Input: the full preview response body. Response: `{ batchId: string, foundItemsCount: number, missingItemsCount: number, unchangedItemsCount: number }`.
+
+The execute endpoint trusts the preview — no re-validation. The location picker allows any location type.
+
 ### Rückgabe (Return)
 
 A ClothingMovement batch where items move from PERSONAL locations to a POOL or WAESCHE location without taking new items. Implemented as a Checkout with null `targetLocationId` and non-empty `returnItemIds`. Returns items may originate from different PERSONAL locations. Movement reason: `RETURN`. Two variants: wash-return (PERSONAL → WAESCHE) and pool-return (PERSONAL → POOL). See ADR-0004.

--- a/server/CONTEXT.md
+++ b/server/CONTEXT.md
@@ -21,6 +21,10 @@ The `type` replaces the older `shouldBeShownOnDashboard` boolean: dashboard visi
 
 The clothing officer role (`UserRole.KLEIDERWART`). Manages clothing types, items, and locations. Distinct from `ADMIN` and `USER`.
 
+### ClothingItemResolver
+
+Owns all read access to `resolved_clothing_item_view`, a PostgreSQL view that left-joins `clothing_items`, `clothing_locations`, and `clothing_types` into a single denormalised row per item. Queried via `JdbcTemplate` + custom `RowMapper` that hydrates the nested `ResolvedClothingItem` DTO. Three methods: `resolveOne(id)`, `resolveAll()`, `resolveByBarcode(barcode)`. See ADR-0006.
+
 ### ClothingMovement
 
 An append-only record of an item moving from one location to another (or being assigned a location for the first time). One row per item per move. Reasons: `CHECKOUT` (POOL → PERSONAL), `RETURN` (PERSONAL → WAESCHE), `MANUAL_CORRECTION` (Kleiderwart edits), `INITIAL_PLACEMENT` (item created with a location), `RELOCATION` (Kleiderwart bulk move to any location type). Movements created by the same batch operation share a `batchId`. See ADR-0001.

--- a/server/docs/adr/0005-inventory-reconciliation-endpoint.md
+++ b/server/docs/adr/0005-inventory-reconciliation-endpoint.md
@@ -1,0 +1,60 @@
+# ADR-0005: Two-phase inventory reconciliation endpoint with new movement reason
+
+**Status:** Accepted
+**Date:** 2026-06-12
+
+## Context
+
+The Kleiderwart needs to reconcile the system's records for a location against physical reality — scanning all items physically present and having the system compute and apply the differences. The existing Relocation endpoint (ADR-0003) moves items *to* a target in a single phase. The existing Checkout endpoint (ADR-0002) is two-phase but locked to POOL → PERSONAL semantics.
+
+A new Inventarisierung (inventory reconciliation) endpoint is required that:
+- Computes the diff (unchanged / found / missing) server-side
+- Shows the diff before applying changes (two-phase)
+- Accepts any location type
+- Is restricted to `KLEIDERWART`
+- Uses a distinct movement reason to distinguish reconciliation from relocation, checkout, and manual corrections
+
+## Decision
+
+Two endpoints under `POST /api/clothing/inventory-reconciliation/{locationId}/`:
+
+**Phase 1 — `/preview`:**
+- Input: `{ scannedItemIds: number[] }`
+- Compares scanned IDs against the items currently recorded at `locationId`
+- Returns: `{ unchangedItems: ResolvedClothingItem[], foundItems: ResolvedClothingItem[], missingItems: ResolvedClothingItem[] }`
+- No side effects. No transaction.
+
+**Phase 2 — `/execute`:**
+- Input: the full preview response body
+- Writes movements for found items (`fromLocationId = current → toLocationId = checkedLocation`) and missing items (`fromLocationId = checkedLocation → toLocationId = null`)
+- Movement reason: `INVENTORY_RECONCILIATION` for all movements
+- All movements in one `@Transactional` method sharing a UUID `batchId`
+- No re-validation of the preview state — trusts the preview
+- Returns: `{ batchId, foundItemsCount, missingItemsCount, unchangedItemsCount }`
+- Secured via `@PreAuthorize("hasRole('ROLE_KLEIDERWART')")`
+
+### Why two-phase instead of single-phase?
+
+The preview gives the Kleiderwart a confirmation safety net before an irreversible batch change. Unlike Relocation (where the operator knows exactly what's being moved), Inventarisierung produces a computed diff that the operator should review.
+
+### Why no re-validation on execute?
+
+Unlike Checkout (ADR-0002), Inventarisierung is Kleiderwart-only and runs in a single session. The window between preview and execute has a single actor; concurrent changes are negligible. The Kleiderwart is the authority — re-validating adds complexity for no practical benefit.
+
+### Why a new movement reason?
+
+Using `MANUAL_CORRECTION` would make bulk inventory checks indistinguishable in the audit log from single-item Kleiderwart edits. `INVENTORY_RECONCILIATION` allows auditors to distinguish "found/missing during an inventory check" from "manual correction by the Kleiderwart."
+
+## Consequences
+
+- No migration needed since `reason` is stored as `VARCHAR` in the database.
+- `INVENTORY_RECONCILIATION` rows will appear in the movement log for both found and missing items, all sharing the same `batchId`.
+- Items moved to `null` ("Kein Standort") appear in the log with `toLocationId = null`, consistent with the existing nullable column.
+- The preview response uses `ResolvedClothingItem` for all items, which already carries `clothingItem`, `location`, and `clothingType` — sufficient for diff display.
+
+## Alternatives Rejected
+
+- **Single-phase (preview + execute combined into one call):** Loses the confirmation safety net. The diff is only visible after the changes are applied.
+- **Reusing `MANUAL_CORRECTION` reason:** Loses audit trail clarity. A future "when was item X lost?" query cannot distinguish a bulk inventory result from a one-off manual edit.
+- **Revalidation on execute:** The window is a single Kleiderwart session. Re-validation adds complexity for no practical benefit.
+- **Client-side diff:** Duplicates logic and makes reconciliation unavailable to non-UI consumers.

--- a/server/docs/adr/0006-resolved-clothing-item-view.md
+++ b/server/docs/adr/0006-resolved-clothing-item-view.md
@@ -1,0 +1,54 @@
+# ADR-0006: PostgreSQL view for resolved clothing items
+
+**Status:** Accepted
+**Date:** 2026-06-12
+
+## Context
+
+`ResolvedClothingItem` bundles a `ClothingItem` with its `ClothingLocation` and `ClothingType`. Multiple services need this denormalised shape: `ClothingItemLookupService` (barcode lookup, search), `ClothingItemResolver` (single/batch resolution), and `InventoryReconciliationService` (preview). The assembly pattern across all these consumers loads items, types, and locations separately — either as individual `findById` lookups (N+1 per item) or as full-table loads into memory maps. This is correct but inefficient as the number of items grows.
+
+A PostgreSQL view (`resolved_clothing_item_view`) that left-joins the three tables would reduce every resolution path to a single query.
+
+## Decision
+
+- Create `resolved_clothing_item_view` via V017 migration:
+  ```sql
+  CREATE VIEW resolved_clothing_item_view AS
+  SELECT
+    c_i.id AS item_id, ... ,
+    c_l.id AS location_id, ... ,
+    c_t.id AS type_id, ...
+  FROM clothing_items c_i
+  LEFT JOIN clothing_locations c_l ON c_l.id = c_i.location_id
+  JOIN clothing_types c_t ON c_t.id = c_i.type_id
+  ```
+  All 12 metadata columns from the three tables are included with table-prefixed aliases.
+- `ClothingItemResolver` owns all view access via `JdbcTemplate` + a custom `RowMapper` that hydrates `ResolvedClothingItem` from the flat row. Three methods: `resolveOne(id)`, `resolveAll()`, `resolveByBarcode(barcode)`.
+- `ClothingItemResolver` drops its `ClothingItemRepository`, `ClothingTypeRepository`, and `ClothingLocationRepository` dependencies.
+- `ClothingItemLookupService` drops `ClothingTypeRepository` and `ClothingLocationRepository`; its `findByBarcode` delegates to `resolveByBarcode` and its `search` method calls `resolveAll()` then filters by text and Kleiderwart visibility in-memory.
+- The `ResolvedClothingItem` DTO shape (nested entities) remains unchanged — consumers see no difference.
+
+### Why `JdbcTemplate` instead of Spring Data JDBC?
+
+The view returns plain `Long?` columns for foreign keys, not `AggregateReference` objects. Spring Data JDBC cannot map the view to the existing entity classes. A custom `RowMapper` avoids creating a separate read-model entity class and keeps the mapping logic close to the query.
+
+### Why `resolveAll()` for search instead of a filtered view query?
+
+PostgreSQL views do not support parameterised filtering. `resolveAll()` loads all rows from the view, then the caller filters by text and visibility in Kotlin — same logic as the old `search()` method, same 50-result cap, but replacing three repository loads with one view query.
+
+### Why not a materialised view?
+
+The data volume is small (hundreds of clothing items, tens of locations, tens of types). A regular view computes the join at query time with negligible cost. A materialised view would add refresh management complexity for no performance gain.
+
+## Consequences
+
+- `ClothingItemLookupService.search()` still loads all items into memory but now as a single query instead of three.
+- `ClothingItemResolver.resolveOne()` goes from up to 3 queries to 1.
+- The view is read-only — write paths through `ClothingItemRepository`, `ClothingLocationRepository`, and `ClothingTypeRepository` are unaffected.
+- A new pattern (`JdbcTemplate` + `RowMapper`) enters the codebase, previously used only in migrations.
+
+## Alternatives Rejected
+
+- **Keep in-memory assembly.** Works and is simple, but the N+1 query pattern scales poorly and `search()` already loads everything into memory anyway — a view eliminates the N+1 without adding complexity.
+- **Materialised view.** Adds refresh management (triggers, cron, or manual refresh) for a dataset that fits in memory. No benefit at current scale.
+- **Spring Data JDBC mapping to the view.** Requires `AggregateReference` fields that the view cannot produce because FK columns in the view are plain values, not references. Would need a new entity class anyway — `JdbcTemplate` is simpler.

--- a/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/inventoryreconciliation/InventoryReconciliationApi.kt
+++ b/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/inventoryreconciliation/InventoryReconciliationApi.kt
@@ -1,0 +1,18 @@
+package io.github.simonhauck.openfirestationmanager.clothing.inventoryreconciliation
+
+import io.github.simonhauck.openfirestationmanager.clothing.item.ResolvedClothingItem
+
+data class InventoryReconciliationPreviewRequest(val scannedItemIds: List<Long>)
+
+data class InventoryReconciliationPreviewResponse(
+    val unchangedItems: List<ResolvedClothingItem>,
+    val foundItems: List<ResolvedClothingItem>,
+    val missingItems: List<ResolvedClothingItem>,
+)
+
+data class InventoryReconciliationExecuteResponse(
+    val batchId: String,
+    val foundItemsCount: Int,
+    val missingItemsCount: Int,
+    val unchangedItemsCount: Int,
+)

--- a/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/inventoryreconciliation/InventoryReconciliationController.kt
+++ b/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/inventoryreconciliation/InventoryReconciliationController.kt
@@ -1,0 +1,75 @@
+package io.github.simonhauck.openfirestationmanager.clothing.inventoryreconciliation
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import jakarta.validation.Valid
+import org.springframework.http.ProblemDetail
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/clothing/inventory-reconciliation/{locationId}")
+@Validated
+class InventoryReconciliationController(private val service: InventoryReconciliationService) {
+
+    @PostMapping("/preview")
+    @PreAuthorize("hasRole('ROLE_KLEIDERWART')")
+    @Operation(summary = "Preview the diff between scanned items and system records for a location")
+    @ApiResponse(responseCode = "200", description = "OK")
+    @ApiResponse(
+        responseCode = "400",
+        description = "Bad Request",
+        content = [Content(schema = Schema(implementation = ProblemDetail::class))],
+    )
+    @ApiResponse(
+        responseCode = "403",
+        description = "Forbidden — KLEIDERWART role required",
+        content = [Content(schema = Schema(implementation = ProblemDetail::class))],
+    )
+    @ApiResponse(
+        responseCode = "404",
+        description = "Location or item not found",
+        content = [Content(schema = Schema(implementation = ProblemDetail::class))],
+    )
+    fun preview(
+        @PathVariable locationId: Long,
+        @Valid @RequestBody request: InventoryReconciliationPreviewRequest,
+    ): InventoryReconciliationPreviewResponse {
+        return service.preview(locationId, request)
+    }
+
+    @PostMapping("/execute")
+    @PreAuthorize("hasRole('ROLE_KLEIDERWART')")
+    @Operation(
+        summary = "Execute the inventory reconciliation, applying the changes from the preview"
+    )
+    @ApiResponse(responseCode = "200", description = "OK")
+    @ApiResponse(
+        responseCode = "400",
+        description = "Bad Request",
+        content = [Content(schema = Schema(implementation = ProblemDetail::class))],
+    )
+    @ApiResponse(
+        responseCode = "403",
+        description = "Forbidden — KLEIDERWART role required",
+        content = [Content(schema = Schema(implementation = ProblemDetail::class))],
+    )
+    @ApiResponse(
+        responseCode = "404",
+        description = "Location or item not found",
+        content = [Content(schema = Schema(implementation = ProblemDetail::class))],
+    )
+    fun execute(
+        @PathVariable locationId: Long,
+        @Valid @RequestBody request: InventoryReconciliationPreviewResponse,
+    ): InventoryReconciliationExecuteResponse {
+        return service.execute(locationId, request)
+    }
+}

--- a/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/inventoryreconciliation/InventoryReconciliationService.kt
+++ b/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/inventoryreconciliation/InventoryReconciliationService.kt
@@ -11,7 +11,6 @@ import io.github.simonhauck.openfirestationmanager.clothing.movement.MovementRea
 import io.github.simonhauck.openfirestationmanager.clothing.movement.MovementService
 import io.github.simonhauck.openfirestationmanager.common.PublicApiException
 import java.util.UUID
-import org.springframework.data.jdbc.core.mapping.AggregateReference
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -31,9 +30,7 @@ class InventoryReconciliationService(
         val location = getLocationOrThrow(locationId)
 
         val itemsAtLocation =
-            itemRepository
-                .findAllByLocationId(location.getIdAsReference())
-                .associateBy { it.id }
+            itemRepository.findAllByLocationId(location.getIdAsReference()).associateBy { it.id }
 
         val scannedItemIds = request.scannedItemIds.toSet()
         val unchanged: MutableList<ResolvedClothingItem> = mutableListOf()

--- a/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/inventoryreconciliation/InventoryReconciliationService.kt
+++ b/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/inventoryreconciliation/InventoryReconciliationService.kt
@@ -2,14 +2,13 @@ package io.github.simonhauck.openfirestationmanager.clothing.inventoryreconcilia
 
 import io.github.simonhauck.openfirestationmanager.clothing.item.ClothingItem
 import io.github.simonhauck.openfirestationmanager.clothing.item.ClothingItemRepository
+import io.github.simonhauck.openfirestationmanager.clothing.item.ClothingItemResolver
 import io.github.simonhauck.openfirestationmanager.clothing.item.ResolvedClothingItem
 import io.github.simonhauck.openfirestationmanager.clothing.location.ClothingLocation
 import io.github.simonhauck.openfirestationmanager.clothing.location.ClothingLocationRepository
 import io.github.simonhauck.openfirestationmanager.clothing.movement.ClothingMovement
 import io.github.simonhauck.openfirestationmanager.clothing.movement.MovementReason
 import io.github.simonhauck.openfirestationmanager.clothing.movement.MovementService
-import io.github.simonhauck.openfirestationmanager.clothing.type.ClothingType
-import io.github.simonhauck.openfirestationmanager.clothing.type.ClothingTypeRepository
 import io.github.simonhauck.openfirestationmanager.common.PublicApiException
 import java.util.UUID
 import org.springframework.data.jdbc.core.mapping.AggregateReference
@@ -22,7 +21,7 @@ class InventoryReconciliationService(
     private val itemRepository: ClothingItemRepository,
     private val movementService: MovementService,
     private val clothingLocationRepository: ClothingLocationRepository,
-    private val typeRepository: ClothingTypeRepository,
+    private val itemResolver: ClothingItemResolver,
 ) {
 
     fun preview(
@@ -30,13 +29,11 @@ class InventoryReconciliationService(
         request: InventoryReconciliationPreviewRequest,
     ): InventoryReconciliationPreviewResponse {
         val location = getLocationOrThrow(locationId)
-        val types = typeRepository.findAll().associateBy { it.id }
-        val locations = clothingLocationRepository.findAll().associateBy { it.id }
 
         val itemsAtLocation =
-            itemRepository.findAllByLocationId(AggregateReference.to(locationId)).associateBy {
-                it.id
-            }
+            itemRepository
+                .findAllByLocationId(location.getIdAsReference())
+                .associateBy { it.id }
 
         val scannedItemIds = request.scannedItemIds.toSet()
         val unchanged: MutableList<ResolvedClothingItem> = mutableListOf()
@@ -44,23 +41,17 @@ class InventoryReconciliationService(
         val missing: MutableList<ResolvedClothingItem> = mutableListOf()
 
         for (scannedId in scannedItemIds) {
-            val item =
-                itemRepository.findById(scannedId)
-                    ?: throw PublicApiException(
-                        HttpStatus.NOT_FOUND,
-                        "Item with id $scannedId not found",
-                    )
-            val resolved = resolveItem(item, types, locations)
-            if (item.locationId?.id == locationId) {
+            val resolved = itemResolver.resolveOne(scannedId)
+            if (resolved.clothingItem.locationId?.id == locationId) {
                 unchanged.add(resolved)
             } else {
                 found.add(resolved)
             }
         }
 
-        for ((itemId, item) in itemsAtLocation) {
+        for ((itemId) in itemsAtLocation) {
             if (itemId !in scannedItemIds) {
-                val resolved = resolveItem(item, types, locations)
+                val resolved = itemResolver.resolveOne(itemId)
                 missing.add(resolved)
             }
         }
@@ -133,21 +124,6 @@ class InventoryReconciliationService(
             missingItemsCount = request.missingItems.size,
             unchangedItemsCount = request.unchangedItems.size,
         )
-    }
-
-    private fun resolveItem(
-        item: ClothingItem,
-        types: Map<Long, ClothingType>,
-        locations: Map<Long, ClothingLocation>,
-    ): ResolvedClothingItem {
-        val location = item.locationId?.id?.let { locations[it] }
-        val type =
-            types[item.typeId.id]
-                ?: throw PublicApiException(
-                    HttpStatus.INTERNAL_SERVER_ERROR,
-                    "Type not found for item ${item.id}",
-                )
-        return ResolvedClothingItem(clothingItem = item, location = location, clothingType = type)
     }
 
     private fun getLocationOrThrow(id: Long): ClothingLocation {

--- a/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/inventoryreconciliation/InventoryReconciliationService.kt
+++ b/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/inventoryreconciliation/InventoryReconciliationService.kt
@@ -1,0 +1,162 @@
+package io.github.simonhauck.openfirestationmanager.clothing.inventoryreconciliation
+
+import io.github.simonhauck.openfirestationmanager.clothing.item.ClothingItem
+import io.github.simonhauck.openfirestationmanager.clothing.item.ClothingItemRepository
+import io.github.simonhauck.openfirestationmanager.clothing.item.ResolvedClothingItem
+import io.github.simonhauck.openfirestationmanager.clothing.location.ClothingLocation
+import io.github.simonhauck.openfirestationmanager.clothing.location.ClothingLocationRepository
+import io.github.simonhauck.openfirestationmanager.clothing.movement.ClothingMovement
+import io.github.simonhauck.openfirestationmanager.clothing.movement.MovementReason
+import io.github.simonhauck.openfirestationmanager.clothing.movement.MovementService
+import io.github.simonhauck.openfirestationmanager.clothing.type.ClothingType
+import io.github.simonhauck.openfirestationmanager.clothing.type.ClothingTypeRepository
+import io.github.simonhauck.openfirestationmanager.common.PublicApiException
+import java.util.UUID
+import org.springframework.data.jdbc.core.mapping.AggregateReference
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class InventoryReconciliationService(
+    private val itemRepository: ClothingItemRepository,
+    private val movementService: MovementService,
+    private val clothingLocationRepository: ClothingLocationRepository,
+    private val typeRepository: ClothingTypeRepository,
+) {
+
+    fun preview(
+        locationId: Long,
+        request: InventoryReconciliationPreviewRequest,
+    ): InventoryReconciliationPreviewResponse {
+        val location = getLocationOrThrow(locationId)
+        val types = typeRepository.findAll().associateBy { it.id }
+        val locations = clothingLocationRepository.findAll().associateBy { it.id }
+
+        val itemsAtLocation =
+            itemRepository.findAllByLocationId(AggregateReference.to(locationId)).associateBy {
+                it.id
+            }
+
+        val scannedItemIds = request.scannedItemIds.toSet()
+        val unchanged: MutableList<ResolvedClothingItem> = mutableListOf()
+        val found: MutableList<ResolvedClothingItem> = mutableListOf()
+        val missing: MutableList<ResolvedClothingItem> = mutableListOf()
+
+        for (scannedId in scannedItemIds) {
+            val item =
+                itemRepository.findById(scannedId)
+                    ?: throw PublicApiException(
+                        HttpStatus.NOT_FOUND,
+                        "Item with id $scannedId not found",
+                    )
+            val resolved = resolveItem(item, types, locations)
+            if (item.locationId?.id == locationId) {
+                unchanged.add(resolved)
+            } else {
+                found.add(resolved)
+            }
+        }
+
+        for ((itemId, item) in itemsAtLocation) {
+            if (itemId !in scannedItemIds) {
+                val resolved = resolveItem(item, types, locations)
+                missing.add(resolved)
+            }
+        }
+
+        return InventoryReconciliationPreviewResponse(
+            unchangedItems = unchanged,
+            foundItems = found,
+            missingItems = missing,
+        )
+    }
+
+    @Transactional
+    fun execute(
+        locationId: Long,
+        request: InventoryReconciliationPreviewResponse,
+    ): InventoryReconciliationExecuteResponse {
+        val location = getLocationOrThrow(locationId)
+        val batchId = UUID.randomUUID().toString()
+
+        val foundMovements =
+            request.foundItems.map { resolved ->
+                val item = getClothingItemOrThrow(resolved.clothingItem.id)
+                ClothingMovement(
+                    item.getIdAsReference(),
+                    item.locationId,
+                    location.getIdAsReference(),
+                    MovementReason.INVENTORY_RECONCILIATION,
+                    batchId,
+                )
+            }
+
+        val missingMovements =
+            request.missingItems.map { resolved ->
+                val item = getClothingItemOrThrow(resolved.clothingItem.id)
+                ClothingMovement(
+                    item.getIdAsReference(),
+                    location.getIdAsReference(),
+                    null,
+                    MovementReason.INVENTORY_RECONCILIATION,
+                    batchId,
+                )
+            }
+
+        val allMovements = foundMovements + missingMovements
+        if (allMovements.isNotEmpty()) {
+            movementService.recordMovements(allMovements)
+        }
+
+        if (request.foundItems.isNotEmpty()) {
+            val foundUpdates =
+                request.foundItems.map { resolved ->
+                    val item = getClothingItemOrThrow(resolved.clothingItem.id)
+                    item.copy(locationId = location.getIdAsReference())
+                }
+            itemRepository.saveAll(foundUpdates)
+        }
+
+        if (request.missingItems.isNotEmpty()) {
+            val missingUpdates =
+                request.missingItems.map { resolved ->
+                    val item = getClothingItemOrThrow(resolved.clothingItem.id)
+                    item.copy(locationId = null)
+                }
+            itemRepository.saveAll(missingUpdates)
+        }
+
+        return InventoryReconciliationExecuteResponse(
+            batchId = batchId,
+            foundItemsCount = request.foundItems.size,
+            missingItemsCount = request.missingItems.size,
+            unchangedItemsCount = request.unchangedItems.size,
+        )
+    }
+
+    private fun resolveItem(
+        item: ClothingItem,
+        types: Map<Long, ClothingType>,
+        locations: Map<Long, ClothingLocation>,
+    ): ResolvedClothingItem {
+        val location = item.locationId?.id?.let { locations[it] }
+        val type =
+            types[item.typeId.id]
+                ?: throw PublicApiException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "Type not found for item ${item.id}",
+                )
+        return ResolvedClothingItem(clothingItem = item, location = location, clothingType = type)
+    }
+
+    private fun getLocationOrThrow(id: Long): ClothingLocation {
+        return clothingLocationRepository.findById(id)
+            ?: throw PublicApiException(HttpStatus.NOT_FOUND, "Location with id $id not found")
+    }
+
+    private fun getClothingItemOrThrow(id: Long): ClothingItem {
+        return itemRepository.findById(id)
+            ?: throw PublicApiException(HttpStatus.NOT_FOUND, "Item with id $id not found")
+    }
+}

--- a/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ClothingItemLookupService.kt
+++ b/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ClothingItemLookupService.kt
@@ -12,6 +12,7 @@ class ClothingItemLookupService(
     private val itemRepository: ClothingItemRepository,
     private val typeRepository: ClothingTypeRepository,
     private val locationRepository: ClothingLocationRepository,
+    private val itemResolver: ClothingItemResolver,
 ) {
 
     fun findByBarcode(barcode: String, isKleiderwart: Boolean): ResolvedClothingItem {
@@ -19,17 +20,17 @@ class ClothingItemLookupService(
             itemRepository.findByBarcode(barcode)
                 ?: throw NotFoundException("Item not found for barcode: $barcode")
 
-        val location = item.locationId?.id?.let { locationRepository.findById(it) }
+        val resolved = itemResolver.resolveOne(item.id)
 
-        if (location != null && location.onlyVisibleForKleiderwart && !isKleiderwart) {
+        if (
+            resolved.location != null &&
+            resolved.location.onlyVisibleForKleiderwart &&
+            !isKleiderwart
+        ) {
             throw NotFoundException("Item not found for barcode: $barcode")
         }
 
-        val type =
-            typeRepository.findById(item.typeId.id)
-                ?: throw NotFoundException("Type not found for item ${item.id}")
-
-        return ResolvedClothingItem(clothingItem = item, location = location, clothingType = type)
+        return resolved
     }
 
     fun search(q: String, limit: Int, isKleiderwart: Boolean): List<ResolvedClothingItem> {

--- a/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ClothingItemLookupService.kt
+++ b/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ClothingItemLookupService.kt
@@ -1,31 +1,22 @@
 package io.github.simonhauck.openfirestationmanager.clothing.item
 
-import io.github.simonhauck.openfirestationmanager.clothing.location.ClothingLocationRepository
-import io.github.simonhauck.openfirestationmanager.clothing.type.ClothingTypeRepository
 import io.github.simonhauck.openfirestationmanager.common.NotFoundException
 import org.springframework.stereotype.Service
 
 private const val SEARCH_RESULT_CAP = 50
 
 @Service
-class ClothingItemLookupService(
-    private val itemRepository: ClothingItemRepository,
-    private val typeRepository: ClothingTypeRepository,
-    private val locationRepository: ClothingLocationRepository,
-    private val itemResolver: ClothingItemResolver,
-) {
+class ClothingItemLookupService(private val itemResolver: ClothingItemResolver) {
 
     fun findByBarcode(barcode: String, isKleiderwart: Boolean): ResolvedClothingItem {
-        val item =
-            itemRepository.findByBarcode(barcode)
+        val resolved =
+            itemResolver.resolveByBarcode(barcode)
                 ?: throw NotFoundException("Item not found for barcode: $barcode")
-
-        val resolved = itemResolver.resolveOne(item.id)
 
         if (
             resolved.location != null &&
-            resolved.location.onlyVisibleForKleiderwart &&
-            !isKleiderwart
+                resolved.location.onlyVisibleForKleiderwart &&
+                !isKleiderwart
         ) {
             throw NotFoundException("Item not found for barcode: $barcode")
         }
@@ -37,31 +28,19 @@ class ClothingItemLookupService(
         val effectiveLimit = minOf(limit, SEARCH_RESULT_CAP)
         val query = q.lowercase()
 
-        val types = typeRepository.findAll().associateBy { it.id }
-        val locations = locationRepository.findAll().associateBy { it.id }
-
-        return itemRepository
-            .findAll()
+        return itemResolver
+            .resolveAll()
             .asSequence()
-            .filter { item ->
-                val location = item.locationId?.id?.let { locations[it] }
+            .filter { resolved ->
+                val location = resolved.location
                 if (location != null && location.onlyVisibleForKleiderwart && !isKleiderwart)
                     return@filter false
-                val typeName = types[item.typeId.id]?.name ?: ""
-                typeName.lowercase().contains(query) ||
-                    item.size.lowercase().contains(query) ||
-                    (item.barcode?.lowercase()?.contains(query) == true)
+                val typeName = resolved.clothingType.name.lowercase()
+                typeName.contains(query) ||
+                    resolved.clothingItem.size.lowercase().contains(query) ||
+                    (resolved.clothingItem.barcode?.lowercase()?.contains(query) == true)
             }
             .take(effectiveLimit)
-            .map { item ->
-                val location = item.locationId?.id?.let { locations[it] }
-                ResolvedClothingItem(
-                    clothingItem = item,
-                    location = location,
-                    clothingType =
-                        types[item.typeId.id] ?: error("Type not found for item ${item.id}"),
-                )
-            }
             .toList()
     }
 }

--- a/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ClothingItemResolver.kt
+++ b/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ClothingItemResolver.kt
@@ -1,0 +1,62 @@
+package io.github.simonhauck.openfirestationmanager.clothing.item
+
+import io.github.simonhauck.openfirestationmanager.clothing.location.ClothingLocation
+import io.github.simonhauck.openfirestationmanager.clothing.location.ClothingLocationRepository
+import io.github.simonhauck.openfirestationmanager.clothing.type.ClothingType
+import io.github.simonhauck.openfirestationmanager.clothing.type.ClothingTypeRepository
+import io.github.simonhauck.openfirestationmanager.common.PublicApiException
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+
+@Service
+class ClothingItemResolver(
+    private val itemRepository: ClothingItemRepository,
+    private val typeRepository: ClothingTypeRepository,
+    private val clothingLocationRepository: ClothingLocationRepository,
+) {
+
+    fun resolveOne(itemId: Long): ResolvedClothingItem {
+        val item =
+            itemRepository.findById(itemId)
+                ?: throw PublicApiException(HttpStatus.NOT_FOUND, "Item with id $itemId not found")
+        return resolve(item)
+    }
+
+    fun resolveMany(itemIds: List<Long>): List<ResolvedClothingItem> {
+        val types = typeRepository.findAll().associateBy { it.id }
+        val locations = clothingLocationRepository.findAll().associateBy { it.id }
+
+        return itemIds.map { id ->
+            val item =
+                itemRepository.findById(id)
+                    ?: throw PublicApiException(HttpStatus.NOT_FOUND, "Item with id $id not found")
+            resolve(item, types, locations)
+        }
+    }
+
+    private fun resolve(item: ClothingItem): ResolvedClothingItem {
+        val location = item.locationId?.id?.let { clothingLocationRepository.findById(it) }
+        val type =
+            typeRepository.findById(item.typeId.id)
+                ?: throw PublicApiException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "Type not found for item ${item.id}",
+                )
+        return ResolvedClothingItem(clothingItem = item, location = location, clothingType = type)
+    }
+
+    private fun resolve(
+        item: ClothingItem,
+        types: Map<Long, ClothingType>,
+        locations: Map<Long, ClothingLocation>,
+    ): ResolvedClothingItem {
+        val location = item.locationId?.id?.let { locations[it] }
+        val type =
+            types[item.typeId.id]
+                ?: throw PublicApiException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "Type not found for item ${item.id}",
+                )
+        return ResolvedClothingItem(clothingItem = item, location = location, clothingType = type)
+    }
+}

--- a/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ClothingItemResolver.kt
+++ b/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/item/ClothingItemResolver.kt
@@ -1,62 +1,109 @@
 package io.github.simonhauck.openfirestationmanager.clothing.item
 
 import io.github.simonhauck.openfirestationmanager.clothing.location.ClothingLocation
-import io.github.simonhauck.openfirestationmanager.clothing.location.ClothingLocationRepository
+import io.github.simonhauck.openfirestationmanager.clothing.location.LocationType
 import io.github.simonhauck.openfirestationmanager.clothing.type.ClothingType
-import io.github.simonhauck.openfirestationmanager.clothing.type.ClothingTypeRepository
 import io.github.simonhauck.openfirestationmanager.common.PublicApiException
+import io.github.simonhauck.openfirestationmanager.db.EntityMetaData
+import java.sql.ResultSet
+import java.sql.Timestamp
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import org.springframework.data.jdbc.core.mapping.AggregateReference
 import org.springframework.http.HttpStatus
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.core.RowMapper
 import org.springframework.stereotype.Service
 
 @Service
-class ClothingItemResolver(
-    private val itemRepository: ClothingItemRepository,
-    private val typeRepository: ClothingTypeRepository,
-    private val clothingLocationRepository: ClothingLocationRepository,
-) {
+class ClothingItemResolver(private val jdbcTemplate: JdbcTemplate) {
 
     fun resolveOne(itemId: Long): ResolvedClothingItem {
-        val item =
-            itemRepository.findById(itemId)
-                ?: throw PublicApiException(HttpStatus.NOT_FOUND, "Item with id $itemId not found")
-        return resolve(item)
-    }
-
-    fun resolveMany(itemIds: List<Long>): List<ResolvedClothingItem> {
-        val types = typeRepository.findAll().associateBy { it.id }
-        val locations = clothingLocationRepository.findAll().associateBy { it.id }
-
-        return itemIds.map { id ->
-            val item =
-                itemRepository.findById(id)
-                    ?: throw PublicApiException(HttpStatus.NOT_FOUND, "Item with id $id not found")
-            resolve(item, types, locations)
+        val results =
+            jdbcTemplate.query(
+                "SELECT * FROM resolved_clothing_item_view WHERE item_id = ?",
+                rowMapper,
+                itemId,
+            )
+        if (results.isEmpty()) {
+            throw PublicApiException(HttpStatus.NOT_FOUND, "Item with id $itemId not found")
         }
+        return results.first()
     }
 
-    private fun resolve(item: ClothingItem): ResolvedClothingItem {
-        val location = item.locationId?.id?.let { clothingLocationRepository.findById(it) }
-        val type =
-            typeRepository.findById(item.typeId.id)
-                ?: throw PublicApiException(
-                    HttpStatus.INTERNAL_SERVER_ERROR,
-                    "Type not found for item ${item.id}",
-                )
-        return ResolvedClothingItem(clothingItem = item, location = location, clothingType = type)
+    fun resolveAll(): List<ResolvedClothingItem> {
+        return jdbcTemplate.query("SELECT * FROM resolved_clothing_item_view", rowMapper)
     }
 
-    private fun resolve(
-        item: ClothingItem,
-        types: Map<Long, ClothingType>,
-        locations: Map<Long, ClothingLocation>,
-    ): ResolvedClothingItem {
-        val location = item.locationId?.id?.let { locations[it] }
-        val type =
-            types[item.typeId.id]
-                ?: throw PublicApiException(
-                    HttpStatus.INTERNAL_SERVER_ERROR,
-                    "Type not found for item ${item.id}",
-                )
-        return ResolvedClothingItem(clothingItem = item, location = location, clothingType = type)
+    fun resolveByBarcode(barcode: String): ResolvedClothingItem? {
+        val results =
+            jdbcTemplate.query(
+                "SELECT * FROM resolved_clothing_item_view WHERE item_barcode = ?",
+                rowMapper,
+                barcode,
+            )
+        return results.firstOrNull()
+    }
+
+    private val rowMapper = RowMapper { rs, _ ->
+        val item = buildClothingItem(rs)
+        val location = buildClothingLocation(rs)
+        val type = buildClothingType(rs)
+        ResolvedClothingItem(clothingItem = item, location = location, clothingType = type)
+    }
+
+    private fun buildClothingItem(rs: ResultSet): ClothingItem {
+        val locationId: AggregateReference<ClothingLocation, Long>? =
+            rs.getNullableLong("item_location_id")?.let { AggregateReference.to(it) }
+
+        return ClothingItem(
+            id = rs.getLong("item_id"),
+            typeId = AggregateReference.to(rs.getLong("item_type_id")),
+            size = rs.getString("item_size"),
+            barcode = rs.getString("item_barcode"),
+            locationId = locationId,
+            metaData = buildMetaData(rs, "item"),
+        )
+    }
+
+    private fun buildClothingLocation(rs: ResultSet): ClothingLocation? {
+        val locationId = rs.getNullableLong("location_id") ?: return null
+        return ClothingLocation(
+            id = locationId,
+            name = rs.getString("location_name"),
+            comment = rs.getString("location_comment"),
+            onlyVisibleForKleiderwart = rs.getBoolean("location_only_visible_for_kleiderwart"),
+            type = LocationType.valueOf(rs.getString("location_type")),
+            metaData = buildMetaData(rs, "location"),
+        )
+    }
+
+    private fun buildClothingType(rs: ResultSet): ClothingType {
+        return ClothingType(
+            id = rs.getLong("type_id"),
+            name = rs.getString("type_name"),
+            metaData = buildMetaData(rs, "type"),
+        )
+    }
+
+    private fun buildMetaData(rs: ResultSet, prefix: String): EntityMetaData {
+        return EntityMetaData(
+            createdAt = rs.getZonedDateTime("${prefix}_created_at"),
+            createdBy = rs.getString("${prefix}_created_by"),
+            lastModifiedAt = rs.getZonedDateTime("${prefix}_last_modified_at"),
+            lastModifiedBy = rs.getString("${prefix}_last_modified_by"),
+        )
+    }
+
+    private fun ResultSet.getNullableLong(column: String): Long? {
+        val value = getLong(column)
+        return if (wasNull()) null else value
+    }
+
+    private fun ResultSet.getZonedDateTime(column: String): ZonedDateTime {
+        val timestamp: Timestamp? = getTimestamp(column)
+        return timestamp?.toInstant()?.atZone(ZoneId.of(ZoneOffset.UTC.id))
+            ?: ZonedDateTime.ofInstant(java.time.Instant.EPOCH, ZoneId.of(ZoneOffset.UTC.id))
     }
 }

--- a/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/movement/ClothingMovement.kt
+++ b/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/clothing/movement/ClothingMovement.kt
@@ -15,6 +15,7 @@ enum class MovementReason {
     MANUAL_CORRECTION,
     INITIAL_PLACEMENT,
     RELOCATION,
+    INVENTORY_RECONCILIATION,
 }
 
 @Table("clothing_movements")

--- a/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/migration/V017CreateResolvedClothingItemView.kt
+++ b/server/src/main/kotlin/io/github/simonhauck/openfirestationmanager/migration/V017CreateResolvedClothingItemView.kt
@@ -1,0 +1,48 @@
+package io.github.simonhauck.openfirestationmanager.migration
+
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class V017CreateResolvedClothingItemView : DatabaseMigration {
+    override val id = "V017__create_resolved_clothing_item_view"
+
+    override fun execute(jdbcTemplate: JdbcTemplate) {
+        jdbcTemplate.execute(
+            """
+            CREATE VIEW resolved_clothing_item_view AS
+            SELECT
+                c_i.id                       AS item_id,
+                c_i.type_id                  AS item_type_id,
+                c_i.size                     AS item_size,
+                c_i.barcode                  AS item_barcode,
+                c_i.location_id              AS item_location_id,
+                c_i.created_at               AS item_created_at,
+                c_i.created_by               AS item_created_by,
+                c_i.last_modified_at         AS item_last_modified_at,
+                c_i.last_modified_by         AS item_last_modified_by,
+
+                c_l.id                       AS location_id,
+                c_l.name                     AS location_name,
+                c_l.comment                  AS location_comment,
+                c_l.only_visible_for_kleiderwart AS location_only_visible_for_kleiderwart,
+                c_l.type                     AS location_type,
+                c_l.created_at               AS location_created_at,
+                c_l.created_by               AS location_created_by,
+                c_l.last_modified_at         AS location_last_modified_at,
+                c_l.last_modified_by         AS location_last_modified_by,
+
+                c_t.id                       AS type_id,
+                c_t.name                     AS type_name,
+                c_t.created_at               AS type_created_at,
+                c_t.created_by               AS type_created_by,
+                c_t.last_modified_at         AS type_last_modified_at,
+                c_t.last_modified_by         AS type_last_modified_by
+            FROM clothing_items c_i
+            LEFT JOIN clothing_locations c_l ON c_l.id = c_i.location_id
+            JOIN clothing_types c_t ON c_t.id = c_i.type_id
+            """
+                .trimIndent()
+        )
+    }
+}

--- a/server/src/main/resources/open-api-contract.json
+++ b/server/src/main/resources/open-api-contract.json
@@ -426,6 +426,146 @@
         }
       }
     },
+    "/api/clothing/inventory-reconciliation/{locationId}/preview": {
+      "post": {
+        "tags": ["inventory-reconciliation-controller"],
+        "summary": "Preview the diff between scanned items and system records for a location",
+        "operationId": "preview",
+        "parameters": [
+          {
+            "name": "locationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InventoryReconciliationPreviewRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryReconciliationPreviewResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — KLEIDERWART role required",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Location or item not found",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/clothing/inventory-reconciliation/{locationId}/execute": {
+      "post": {
+        "tags": ["inventory-reconciliation-controller"],
+        "summary": "Execute the inventory reconciliation, applying the changes from the preview",
+        "operationId": "execute",
+        "parameters": [
+          {
+            "name": "locationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InventoryReconciliationPreviewResponse"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryReconciliationExecuteResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — KLEIDERWART role required",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Location or item not found",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/clothing/checkouts": {
       "post": {
         "tags": ["checkout-controller"],
@@ -1558,6 +1698,84 @@
         },
         "required": ["items"]
       },
+      "InventoryReconciliationPreviewRequest": {
+        "type": "object",
+        "properties": {
+          "scannedItemIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        },
+        "required": ["scannedItemIds"]
+      },
+      "InventoryReconciliationPreviewResponse": {
+        "type": "object",
+        "properties": {
+          "unchangedItems": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResolvedClothingItem"
+            }
+          },
+          "foundItems": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResolvedClothingItem"
+            }
+          },
+          "missingItems": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResolvedClothingItem"
+            }
+          }
+        },
+        "required": ["foundItems", "missingItems", "unchangedItems"]
+      },
+      "ResolvedClothingItem": {
+        "type": "object",
+        "properties": {
+          "clothingItem": {
+            "$ref": "#/components/schemas/ClothingItem"
+          },
+          "location": {
+            "$ref": "#/components/schemas/ClothingLocation"
+          },
+          "clothingType": {
+            "$ref": "#/components/schemas/ClothingType"
+          }
+        },
+        "required": ["clothingItem", "clothingType"]
+      },
+      "InventoryReconciliationExecuteResponse": {
+        "type": "object",
+        "properties": {
+          "batchId": {
+            "type": "string"
+          },
+          "foundItemsCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "missingItemsCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "unchangedItemsCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": [
+          "batchId",
+          "foundItemsCount",
+          "missingItemsCount",
+          "unchangedItemsCount"
+        ]
+      },
       "CheckoutRequest": {
         "type": "object",
         "properties": {
@@ -1777,21 +1995,6 @@
           }
         },
         "required": ["locationId", "locationName", "totalCount", "types"]
-      },
-      "ResolvedClothingItem": {
-        "type": "object",
-        "properties": {
-          "clothingItem": {
-            "$ref": "#/components/schemas/ClothingItem"
-          },
-          "location": {
-            "$ref": "#/components/schemas/ClothingLocation"
-          },
-          "clothingType": {
-            "$ref": "#/components/schemas/ClothingType"
-          }
-        },
-        "required": ["clothingItem", "clothingType"]
       }
     }
   }

--- a/server/src/test/kotlin/io/github/simonhauck/openfirestationmanager/clothing/inventoryreconciliation/InventoryReconciliationControllerCalls.kt
+++ b/server/src/test/kotlin/io/github/simonhauck/openfirestationmanager/clothing/inventoryreconciliation/InventoryReconciliationControllerCalls.kt
@@ -1,0 +1,65 @@
+package io.github.simonhauck.openfirestationmanager.clothing.inventoryreconciliation
+
+import org.springframework.boot.resttestclient.TestRestTemplate
+import org.springframework.boot.resttestclient.postForEntity
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.ProblemDetail
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Component
+
+@Component
+class InventoryReconciliationControllerCalls(private val testRestTemplate: TestRestTemplate) {
+
+    fun preview(
+        locationId: Long,
+        request: InventoryReconciliationPreviewRequest,
+        authCookie: String? = null,
+    ): ResponseEntity<InventoryReconciliationPreviewResponse> {
+        return testRestTemplate.postForEntity(
+            "/api/clothing/inventory-reconciliation/$locationId/preview",
+            HttpEntity(request, headersWithCookie(authCookie)),
+        )
+    }
+
+    fun previewExpectingError(
+        locationId: Long,
+        request: InventoryReconciliationPreviewRequest,
+        authCookie: String? = null,
+    ): ResponseEntity<ProblemDetail> {
+        return testRestTemplate.postForEntity(
+            "/api/clothing/inventory-reconciliation/$locationId/preview",
+            HttpEntity(request, headersWithCookie(authCookie)),
+        )
+    }
+
+    fun execute(
+        locationId: Long,
+        request: InventoryReconciliationPreviewResponse,
+        authCookie: String? = null,
+    ): ResponseEntity<InventoryReconciliationExecuteResponse> {
+        return testRestTemplate.postForEntity(
+            "/api/clothing/inventory-reconciliation/$locationId/execute",
+            HttpEntity(request, headersWithCookie(authCookie)),
+        )
+    }
+
+    fun executeExpectingError(
+        locationId: Long,
+        request: InventoryReconciliationPreviewResponse,
+        authCookie: String? = null,
+    ): ResponseEntity<ProblemDetail> {
+        return testRestTemplate.postForEntity(
+            "/api/clothing/inventory-reconciliation/$locationId/execute",
+            HttpEntity(request, headersWithCookie(authCookie)),
+        )
+    }
+
+    private fun headersWithCookie(authCookie: String?): HttpHeaders {
+        val headers = HttpHeaders()
+        if (authCookie != null) {
+            headers.add(HttpHeaders.COOKIE, authCookie)
+        }
+        return headers
+    }
+}

--- a/server/src/test/kotlin/io/github/simonhauck/openfirestationmanager/clothing/inventoryreconciliation/InventoryReconciliationControllerIT.kt
+++ b/server/src/test/kotlin/io/github/simonhauck/openfirestationmanager/clothing/inventoryreconciliation/InventoryReconciliationControllerIT.kt
@@ -1,0 +1,263 @@
+package io.github.simonhauck.openfirestationmanager.clothing.inventoryreconciliation
+
+import io.github.simonhauck.openfirestationmanager.IntegrationTest
+import io.github.simonhauck.openfirestationmanager.clothing.item.ClothingItem
+import io.github.simonhauck.openfirestationmanager.clothing.item.ClothingItemControllerCalls
+import io.github.simonhauck.openfirestationmanager.clothing.item.ClothingItemRepository
+import io.github.simonhauck.openfirestationmanager.clothing.item.CreateOrUpdateClothingItemRequest
+import io.github.simonhauck.openfirestationmanager.clothing.location.ClothingLocation
+import io.github.simonhauck.openfirestationmanager.clothing.location.ClothingLocationControllerCalls
+import io.github.simonhauck.openfirestationmanager.clothing.location.CreateClothingLocationRequest
+import io.github.simonhauck.openfirestationmanager.clothing.location.LocationType
+import io.github.simonhauck.openfirestationmanager.clothing.movement.ClothingMovementRepository
+import io.github.simonhauck.openfirestationmanager.clothing.movement.MovementReason
+import io.github.simonhauck.openfirestationmanager.clothing.type.ClothingType
+import io.github.simonhauck.openfirestationmanager.clothing.type.CreateOrUpdateClothingTypeRequest
+import io.github.simonhauck.openfirestationmanager.clothing.type.ProtectiveClothingTypeControllerCalls
+import io.github.simonhauck.openfirestationmanager.security.auth.AuthControllerCalls
+import io.github.simonhauck.openfirestationmanager.usermanagement.AdminUserControllerCalls
+import io.github.simonhauck.openfirestationmanager.usermanagement.CreateUserRequest
+import io.github.simonhauck.openfirestationmanager.usermanagement.UserRole
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.jdbc.core.mapping.AggregateReference
+import org.springframework.http.HttpStatus
+
+class InventoryReconciliationControllerIT : IntegrationTest() {
+
+    @Autowired private lateinit var reconciliationCalls: InventoryReconciliationControllerCalls
+    @Autowired private lateinit var itemCalls: ClothingItemControllerCalls
+    @Autowired private lateinit var typeCalls: ProtectiveClothingTypeControllerCalls
+    @Autowired private lateinit var locationCalls: ClothingLocationControllerCalls
+    @Autowired private lateinit var adminUserCalls: AdminUserControllerCalls
+    @Autowired private lateinit var authCalls: AuthControllerCalls
+    @Autowired private lateinit var itemRepository: ClothingItemRepository
+    @Autowired private lateinit var movementRepository: ClothingMovementRepository
+
+    @Test
+    fun `preview correctly identifies unchanged, found, and missing items`() {
+        val type = createType()
+        val location = createLocation(LocationType.POOL)
+        val otherLocation = createLocation(LocationType.OTHER)
+        val itemAtLocation = createItem(type, location)
+        val itemElsewhere = createItem(type, otherLocation)
+        val itemNotScanned = createItem(type, location)
+
+        val response =
+            reconciliationCalls.preview(
+                locationId = location.id,
+                request =
+                    InventoryReconciliationPreviewRequest(
+                        scannedItemIds = listOf(itemAtLocation.id, itemElsewhere.id)
+                    ),
+                authCookie = validCookieHeader,
+            )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        val body = response.body!!
+        assertThat(body.unchangedItems).hasSize(1)
+        assertThat(body.unchangedItems[0].clothingItem.id).isEqualTo(itemAtLocation.id)
+        assertThat(body.foundItems).hasSize(1)
+        assertThat(body.foundItems[0].clothingItem.id).isEqualTo(itemElsewhere.id)
+        assertThat(body.missingItems).hasSize(1)
+        assertThat(body.missingItems[0].clothingItem.id).isEqualTo(itemNotScanned.id)
+    }
+
+    @Test
+    fun `preview returns all items as missing when no items are scanned`() {
+        val type = createType()
+        val location = createLocation(LocationType.POOL)
+        val item1 = createItem(type, location)
+        val item2 = createItem(type, location)
+
+        val response =
+            reconciliationCalls.preview(
+                locationId = location.id,
+                request = InventoryReconciliationPreviewRequest(scannedItemIds = emptyList()),
+                authCookie = validCookieHeader,
+            )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        val body = response.body!!
+        assertThat(body.unchangedItems).isEmpty()
+        assertThat(body.foundItems).isEmpty()
+        assertThat(body.missingItems).hasSize(2)
+    }
+
+    @Test
+    fun `preview returns 404 when location does not exist`() {
+        val response =
+            reconciliationCalls.previewExpectingError(
+                locationId = 999_999_999L,
+                request = InventoryReconciliationPreviewRequest(scannedItemIds = emptyList()),
+                authCookie = validCookieHeader,
+            )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+    }
+
+    @Test
+    fun `preview returns 404 when scanned item does not exist`() {
+        val location = createLocation(LocationType.POOL)
+
+        val response =
+            reconciliationCalls.previewExpectingError(
+                locationId = location.id,
+                request =
+                    InventoryReconciliationPreviewRequest(scannedItemIds = listOf(999_999_999L)),
+                authCookie = validCookieHeader,
+            )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+    }
+
+    @Test
+    fun `preview returns 403 for non-Kleiderwart callers`() {
+        val type = createType()
+        val location = createLocation(LocationType.POOL)
+        val item = createItem(type, location)
+        val userCookie = createRegularUserCookie()
+
+        val response =
+            reconciliationCalls.previewExpectingError(
+                locationId = location.id,
+                request = InventoryReconciliationPreviewRequest(scannedItemIds = listOf(item.id)),
+                authCookie = userCookie,
+            )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
+    }
+
+    @Test
+    fun `execute moves found items to location and missing items to null with INVENTORY_RECONCILIATION movements`() {
+        val type = createType()
+        val location = createLocation(LocationType.POOL)
+        val otherLocation = createLocation(LocationType.OTHER)
+        val itemAtLocation = createItem(type, location)
+        val itemElsewhere = createItem(type, otherLocation)
+        val itemNotScanned = createItem(type, location)
+
+        val previewResponse =
+            reconciliationCalls.preview(
+                locationId = location.id,
+                request =
+                    InventoryReconciliationPreviewRequest(
+                        scannedItemIds = listOf(itemAtLocation.id, itemElsewhere.id)
+                    ),
+                authCookie = validCookieHeader,
+            )
+
+        val previewBody = previewResponse.body!!
+
+        val executeResponse =
+            reconciliationCalls.execute(
+                locationId = location.id,
+                request = previewBody,
+                authCookie = validCookieHeader,
+            )
+
+        assertThat(executeResponse.statusCode).isEqualTo(HttpStatus.OK)
+        val result = executeResponse.body!!
+        assertThat(result.foundItemsCount).isEqualTo(1)
+        assertThat(result.missingItemsCount).isEqualTo(1)
+        assertThat(result.unchangedItemsCount).isEqualTo(1)
+        assertThat(result.batchId).isNotBlank()
+
+        val updatedItem1 = itemRepository.findById(itemAtLocation.id)
+        val updatedItemElsewhere = itemRepository.findById(itemElsewhere.id)
+        val updatedNotScanned = itemRepository.findById(itemNotScanned.id)
+        assertThat(updatedItem1?.locationId?.id).isEqualTo(location.id)
+        assertThat(updatedItemElsewhere?.locationId?.id).isEqualTo(location.id)
+        assertThat(updatedNotScanned?.locationId).isNull()
+
+        val movementsElsewhere =
+            movementRepository.findAllByItemId(AggregateReference.to(itemElsewhere.id))
+        val foundMovement =
+            movementsElsewhere.first { it.reason == MovementReason.INVENTORY_RECONCILIATION }
+        assertThat(foundMovement.fromLocationId?.id).isEqualTo(otherLocation.id)
+        assertThat(foundMovement.toLocationId?.id).isEqualTo(location.id)
+        assertThat(foundMovement.batchId).isEqualTo(result.batchId)
+
+        val movementsMissing =
+            movementRepository.findAllByItemId(AggregateReference.to(itemNotScanned.id))
+        val missingMovement =
+            movementsMissing.first { it.reason == MovementReason.INVENTORY_RECONCILIATION }
+        assertThat(missingMovement.fromLocationId?.id).isEqualTo(location.id)
+        assertThat(missingMovement.toLocationId).isNull()
+        assertThat(missingMovement.batchId).isEqualTo(result.batchId)
+    }
+
+    @Test
+    fun `execute returns 403 for non-Kleiderwart callers`() {
+        val type = createType()
+        val location = createLocation(LocationType.POOL)
+        val item = createItem(type, location)
+        val userCookie = createRegularUserCookie()
+
+        val previewBody =
+            InventoryReconciliationPreviewResponse(
+                unchangedItems = emptyList(),
+                foundItems = emptyList(),
+                missingItems = emptyList(),
+            )
+
+        val response =
+            reconciliationCalls.executeExpectingError(
+                locationId = location.id,
+                request = previewBody,
+                authCookie = userCookie,
+            )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
+    }
+
+    private fun createType(name: String = "Type-${System.nanoTime()}"): ClothingType =
+        typeCalls
+            .createType(CreateOrUpdateClothingTypeRequest(name), authCookie = validCookieHeader)
+            .body!!
+
+    private fun createLocation(
+        type: LocationType,
+        name: String = "Loc-${System.nanoTime()}",
+    ): ClothingLocation =
+        locationCalls
+            .createLocation(
+                CreateClothingLocationRequest(
+                    name = name,
+                    comment = "",
+                    onlyVisibleForKleiderwart = false,
+                    type = type,
+                ),
+                authCookie = validCookieHeader,
+            )
+            .body!!
+
+    private fun createItem(type: ClothingType, location: ClothingLocation): ClothingItem =
+        itemCalls
+            .createItem(
+                CreateOrUpdateClothingItemRequest(
+                    typeId = type.id,
+                    size = "M",
+                    locationId = AggregateReference.to(location.id),
+                ),
+                authCookie = validCookieHeader,
+            )
+            .body!!
+
+    private fun createRegularUserCookie(): String {
+        val username = "user-${System.nanoTime()}"
+        adminUserCalls.createUser(
+            CreateUserRequest(
+                username = username,
+                password = "password",
+                firstName = "Test",
+                lastName = "User",
+                roles = listOf(UserRole.USER),
+            ),
+            authCookie = validCookieHeader,
+        )
+        val loginResponse = authCalls.login(username = username, password = "password")
+        return authCalls.extractAuthCookie(loginResponse)!!
+    }
+}


### PR DESCRIPTION
## Summary

Adds a Kleiderwart-only wizard for reconciling system records against physical reality at a location.

### Backend
- `POST /api/clothing/inventory-reconciliation/{locationId}/preview` — computes diff (unchanged/found/missing), no side effects
- `POST /api/clothing/inventory-reconciliation/{locationId}/execute` — applies changes, returns counts
- New `MovementReason.INVENTORY_RECONCILIATION` for audit trail
- 7 integration tests

### Frontend
- Route: `/pool-clothing/inventory-reconciliation` (KLEIDERWART-only via RoleGuard)
- 4-step wizard: Standort wählen → Kleidung scannen → Differenzen & Bestätigen → Fertig
- Reuses `ClothingItemScanner` with location badges
- Server-side diff via preview/execute two-phase API
- Playwright spec with full happy-path flow

### Documentation
- ADR-0003 (client): Inventory Reconciliation Wizard
- ADR-0005 (server): Two-phase inventory reconciliation endpoint
- Updated `client/CONTEXT.md` and `server/CONTEXT.md`